### PR TITLE
Feature/option builder pattern

### DIFF
--- a/base_agent/rs/Cargo.lock
+++ b/base_agent/rs/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "env_logger",
  "log",

--- a/base_agent/rs/Cargo.toml
+++ b/base_agent/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-agent"
 description = "Standardised use of MQTT and MessagePack for inter-process communication"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -7,7 +7,7 @@ fn main() {
         .port(1883)
         .username("tether")
         .password("sp_ceB0ss!")
-        .finalize()
+        .build()
         .expect("failed to create Tether Agent");
 
     // let output_plug = agent.create_output_plug(name, qos, retain, override_topic)

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -3,7 +3,12 @@ use tether_agent::TetherAgentOptionsBuilder;
 fn main() {
     let agent = TetherAgentOptionsBuilder::new("example")
         .id("customId")
-        .finalize().expect("failed to create Tether Agent");
+        .host("localhost")
+        .port(1883)
+        .username("tether")
+        .password("sp_ceB0ss!")
+        .finalize()
+        .expect("failed to create Tether Agent");
 
-    let output_plug = agent.create_output_plug(name, qos, retain, override_topic)
+    // let output_plug = agent.create_output_plug(name, qos, retain, override_topic)
 }

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -1,0 +1,9 @@
+use tether_agent::TetherAgentOptionsBuilder;
+
+fn main() {
+    let agent = TetherAgentOptionsBuilder::new("example")
+        .id("customId")
+        .finalize().expect("failed to create Tether Agent");
+
+    let output_plug = agent.create_output_plug(name, qos, retain, override_topic)
+}

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -1,7 +1,7 @@
-use tether_agent::TetherAgentOptionsBuilder;
+use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
 
 fn main() {
-    let agent = TetherAgentOptionsBuilder::new("example")
+    let tether_agent = TetherAgentOptionsBuilder::new("example")
         .id("customId")
         .host("localhost")
         .port(1883)
@@ -10,5 +10,13 @@ fn main() {
         .build()
         .expect("failed to create Tether Agent");
 
-    // let output_plug = agent.create_output_plug(name, qos, retain, override_topic)
+    let _output_plug = PlugOptionsBuilder::create_output("anOutput")
+        .qos(2)
+        .retain(true)
+        .build(&tether_agent);
+    let _input_plug = PlugOptionsBuilder::create_input("everything")
+        .topic("#")
+        .build(&tether_agent);
+
+    // And then proceed as usual!
 }

--- a/base_agent/rs/examples/publish.rs
+++ b/base_agent/rs/examples/publish.rs
@@ -25,11 +25,9 @@ fn main() {
     let (role, id) = agent.description();
     info!("Created agent OK: {}, {}", role, id);
 
-    let empty_message_output =
-        PlugOptionsBuilder::create_output(&agent, "nothing").finalize(&agent);
-
-    let boolean_message_output = PlugOptionsBuilder::create_output(&agent, "one").finalize(&agent);
-    let custom_output = PlugOptionsBuilder::create_output(&agent, "two").finalize(&agent);
+    let empty_message_output = PlugOptionsBuilder::create_output("nothing").finalize(&agent);
+    let boolean_message_output = PlugOptionsBuilder::create_output("one").finalize(&agent);
+    let custom_output = PlugOptionsBuilder::create_output("two").finalize(&agent);
 
     for i in 1..=10 {
         info!("#{i}: Sending empty message...");
@@ -41,6 +39,7 @@ fn main() {
             .publish(&boolean_message_output, Some(&[bool.into()]))
             .unwrap();
 
+        info!("#{i}: Sending custom struct message...");
         let custom_message = CustomStruct {
             id: i,
             name: "hello".into(),

--- a/base_agent/rs/examples/publish.rs
+++ b/base_agent/rs/examples/publish.rs
@@ -3,7 +3,7 @@ use std::{thread, time::Duration};
 use env_logger::{Builder, Env};
 use log::{debug, info};
 use serde::Serialize;
-use tether_agent::TetherAgentOptionsBuilder;
+use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,11 +25,11 @@ fn main() {
     let (role, id) = agent.description();
     info!("Created agent OK: {}, {}", role, id);
 
-    let empty_message_output: tether_agent::PlugDefinition = agent
-        .create_output_plug("nothing", None, None, None)
-        .unwrap();
-    let boolean_message_output = agent.create_output_plug("one", None, None, None).unwrap();
-    let custom_output = agent.create_output_plug("two", None, None, None).unwrap();
+    let empty_message_output =
+        PlugOptionsBuilder::create_output(&agent, "nothing").finalize(&agent);
+
+    let boolean_message_output = PlugOptionsBuilder::create_output(&agent, "one").finalize(&agent);
+    let custom_output = PlugOptionsBuilder::create_output(&agent, "two").finalize(&agent);
 
     for i in 1..=10 {
         info!("#{i}: Sending empty message...");

--- a/base_agent/rs/examples/publish.rs
+++ b/base_agent/rs/examples/publish.rs
@@ -20,14 +20,14 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
-        .finalize()
+        .build()
         .expect("failed to connect Tether");
     let (role, id) = agent.description();
     info!("Created agent OK: {}, {}", role, id);
 
-    let empty_message_output = PlugOptionsBuilder::create_output("nothing").finalize(&agent);
-    let boolean_message_output = PlugOptionsBuilder::create_output("one").finalize(&agent);
-    let custom_output = PlugOptionsBuilder::create_output("two").finalize(&agent);
+    let empty_message_output = PlugOptionsBuilder::create_output("nothing").build(&agent);
+    let boolean_message_output = PlugOptionsBuilder::create_output("one").build(&agent);
+    let custom_output = PlugOptionsBuilder::create_output("two").build(&agent);
 
     for i in 1..=10 {
         info!("#{i}: Sending empty message...");

--- a/base_agent/rs/examples/publish.rs
+++ b/base_agent/rs/examples/publish.rs
@@ -3,7 +3,7 @@ use std::{thread, time::Duration};
 use env_logger::{Builder, Env};
 use log::{debug, info};
 use serde::Serialize;
-use tether_agent::TetherAgent;
+use tether_agent::TetherAgentOptionsBuilder;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,11 +19,11 @@ fn main() {
 
     debug!("Debugging is enabled; could be verbose");
 
-    let agent = TetherAgent::new("RustDemoAgent", None, Some(String::from("localhost")));
+    let agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
+        .finalize()
+        .expect("failed to connect Tether");
     let (role, id) = agent.description();
     info!("Created agent OK: {}, {}", role, id);
-
-    agent.connect(None, None).expect("Failed to connect");
 
     let empty_message_output: tether_agent::PlugDefinition = agent
         .create_output_plug("nothing", None, None, None)

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -43,7 +43,7 @@ fn main() {
                 message.topic(),
                 plug_name
             );
-            if &input_one.name() == &plug_name {
+            if &plug_name == input_one.name() {
                 info!(
                     "******** INPUT ONE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
                     input_one.name(),
@@ -51,7 +51,7 @@ fn main() {
                     message.payload().len()
                 );
             }
-            if &input_two.name() == &plug_name {
+            if &plug_name == input_two.name() {
                 info!(
                     "******** INPUT TWO:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
                     input_two.name(),
@@ -71,7 +71,7 @@ fn main() {
                     }
                 };
             }
-            if &input_empty.name() == &plug_name {
+            if &plug_name == input_empty.name() {
                 info!(
                     "******** EMPTY MESSAGE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
                     input_empty.name(),

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -24,14 +24,14 @@ fn main() {
 
     let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
         .id("example")
-        .finalize()
+        .build()
         .expect("failed to init Tether agent");
 
-    let input_one = PlugOptionsBuilder::create_input("one").finalize(&tether_agent);
+    let input_one = PlugOptionsBuilder::create_input("one").build(&tether_agent);
     debug!("input one {} = {}", input_one.name(), input_one.topic());
-    let input_two = PlugOptionsBuilder::create_input("two").finalize(&tether_agent);
+    let input_two = PlugOptionsBuilder::create_input("two").build(&tether_agent);
     debug!("input two {} = {}", input_two.name(), input_two.topic());
-    let input_empty = PlugOptionsBuilder::create_input("nothing").finalize(&tether_agent);
+    let input_empty = PlugOptionsBuilder::create_input("nothing").build(&tether_agent);
 
     info!("Checking messages every 1s, 10x...");
 

--- a/base_agent/rs/examples/subscribe_publish_threaded.rs
+++ b/base_agent/rs/examples/subscribe_publish_threaded.rs
@@ -32,7 +32,7 @@ fn main() {
     let tether_agent = Arc::new(Mutex::new(
         TetherAgentOptionsBuilder::new("RustDemoAgent")
             .id("example")
-            .finalize()
+            .build()
             .expect("failed to init/connect"),
     ));
 
@@ -42,8 +42,8 @@ fn main() {
 
     // Here we call .lock() because it is OK to block while "setting up", connecting
     if let Ok(a) = tether_agent.lock() {
-        let _input_plug = PlugOptionsBuilder::create_input("one").finalize(&a);
-        output_plug = Some(PlugOptionsBuilder::create_output("one").finalize(&a));
+        let _input_plug = PlugOptionsBuilder::create_input("one").build(&a);
+        output_plug = Some(PlugOptionsBuilder::create_output("one").build(&a));
     } else {
         panic!("Error setting up Tether Agent!");
     }

--- a/base_agent/rs/examples/subscribe_publish_threaded.rs
+++ b/base_agent/rs/examples/subscribe_publish_threaded.rs
@@ -20,7 +20,7 @@ use std::{
     time::Duration,
 };
 
-use tether_agent::TetherAgent;
+use tether_agent::{PlugOptionsBuilder, TetherAgent, TetherAgentOptionsBuilder};
 
 fn main() {
     let check_interval = 0.01;
@@ -29,28 +29,26 @@ fn main() {
 
     println!("Rust Tether Agent threaded publish-while-consuming example");
 
-    let agent = Arc::new(Mutex::new(TetherAgent::new(
-        "RustDemoAgent",
-        Some("example"),
-        None,
-    )));
+    let tether_agent = Arc::new(Mutex::new(
+        TetherAgentOptionsBuilder::new("RustDemoAgent")
+            .id("example")
+            .finalize()
+            .expect("failed to init/connect"),
+    ));
+
+    println!("Set up tether agent OK");
 
     let mut output_plug = None;
 
     // Here we call .lock() because it is OK to block while "setting up", connecting
-    if let Ok(a) = agent.lock() {
-        a.connect(None, None).expect("failed to connect");
-        a.create_input_plug("one", None, None)
-            .expect("failed to create Input Plug");
-        let plug = a
-            .create_output_plug("one", None, None, None)
-            .expect("failed to create Output Plug");
-        output_plug = Some(plug);
+    if let Ok(a) = tether_agent.lock() {
+        let _input_plug = PlugOptionsBuilder::create_input("one").finalize(&a);
+        output_plug = Some(PlugOptionsBuilder::create_output("one").finalize(&a));
     } else {
         panic!("Error setting up Tether Agent!");
     }
 
-    let receiver_agent = Arc::clone(&agent);
+    let receiver_agent = Arc::clone(&tether_agent);
     thread::spawn(move || {
         println!("Checking messages every {check_interval}s...");
 
@@ -85,7 +83,7 @@ fn main() {
         }
     });
 
-    let sending_agent = Arc::clone(&agent);
+    let sending_agent = Arc::clone(&tether_agent);
     println!(
         "Sending a message, every {}s, exactly {}x times...",
         publish_interval, publish_count_target

--- a/base_agent/rs/examples/subscribe_threaded.rs
+++ b/base_agent/rs/examples/subscribe_threaded.rs
@@ -20,22 +20,21 @@ use std::{
     time::Duration,
 };
 
-use tether_agent::TetherAgent;
+use tether_agent::{PlugOptionsBuilder, TetherAgent, TetherAgentOptionsBuilder};
 
 fn main() {
     println!("Rust Tether Agent subscribe example");
 
-    let agent = Arc::new(Mutex::new(TetherAgent::new(
-        "RustDemoAgent",
-        Some("example"),
-        None,
-    )));
+    let tether_agent = Arc::new(Mutex::new(
+        TetherAgentOptionsBuilder::new("RustDemoAgent")
+            .id("example")
+            .finalize()
+            .expect("failed to init/connect"),
+    ));
 
-    match agent.lock() {
+    match tether_agent.lock() {
         Ok(a) => {
-            a.connect(None, None).expect("failed to connect");
-            a.create_input_plug("one", None, None)
-                .expect("failed to create Input Plug");
+            let _input_plug = PlugOptionsBuilder::create_output("one").finalize(&a);
         }
         Err(e) => {
             panic!("Failed to acquire lock for Tether Agent setup: {}", e);
@@ -44,7 +43,7 @@ fn main() {
 
     let (tx, rx) = mpsc::channel();
 
-    let receiver_agent = Arc::clone(&agent);
+    let receiver_agent = Arc::clone(&tether_agent);
     thread::spawn(move || {
         println!("Checking messages every 1s, 10x...");
 

--- a/base_agent/rs/examples/subscribe_threaded.rs
+++ b/base_agent/rs/examples/subscribe_threaded.rs
@@ -28,13 +28,13 @@ fn main() {
     let tether_agent = Arc::new(Mutex::new(
         TetherAgentOptionsBuilder::new("RustDemoAgent")
             .id("example")
-            .finalize()
+            .build()
             .expect("failed to init/connect"),
     ));
 
     match tether_agent.lock() {
         Ok(a) => {
-            let _input_plug = PlugOptionsBuilder::create_output("one").finalize(&a);
+            let _input_plug = PlugOptionsBuilder::create_output("one").build(&a);
         }
         Err(e) => {
             panic!("Failed to acquire lock for Tether Agent setup: {}", e);

--- a/base_agent/rs/examples/username_password.rs
+++ b/base_agent/rs/examples/username_password.rs
@@ -23,14 +23,14 @@ fn main() {
         .host("10.112.10.10")
         .username("connected.space")
         .password("connected.space")
-        .finalize()
+        .build()
         .expect("Failed to initialise and connect");
     let (role, id) = tether_agent.description();
     info!("Created agent OK: {}, {}", role, id);
 
-    let empty_message_output = PlugOptionsBuilder::create_output("nothing").finalize(&tether_agent);
-    let boolean_message_output = PlugOptionsBuilder::create_output("one").finalize(&tether_agent);
-    let custom_output = PlugOptionsBuilder::create_output("two").finalize(&tether_agent);
+    let empty_message_output = PlugOptionsBuilder::create_output("nothing").build(&tether_agent);
+    let boolean_message_output = PlugOptionsBuilder::create_output("one").build(&tether_agent);
+    let custom_output = PlugOptionsBuilder::create_output("two").build(&tether_agent);
 
     for i in 1..=10 {
         info!("#{i}: Sending empty message...");

--- a/base_agent/rs/src/lib.rs
+++ b/base_agent/rs/src/lib.rs
@@ -56,6 +56,31 @@ impl TetherAgentOptionsBuilder {
         self
     }
 
+    pub fn host(mut self, host: &str) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub fn username(mut self, username: &str) -> Self {
+        self.username = Some(username.into());
+        self
+    }
+
+    pub fn password(mut self, password: &str) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    pub fn auto_connect(mut self, should_auto_connect: bool) -> Self {
+        self.auto_connect = should_auto_connect;
+        self
+    }
+
     pub fn finalize(&self) -> Result<TetherAgent, ()> {
         let broker_host = self.host.clone().unwrap_or("localhost".into());
         let broker_port = self.port.unwrap_or(1883);

--- a/base_agent/rs/src/lib.rs
+++ b/base_agent/rs/src/lib.rs
@@ -326,49 +326,6 @@ impl TetherAgent {
         }
     }
 
-    // pub fn create_input_plug(&self, definition: InputPlug) -> PlugDefinition {
-    //     let PlugDefinitionCommon { name, topic, qos } = definition.common;
-
-    //     match self.client.subscribe(&topic, qos) {
-    //         Ok(_res) => {
-    //             info!("Subscribed to topic {} OK", &topic);
-    //             let plug = PlugDefinition::InputPlug {
-    //                 common: PlugDefinitionCommon { name, topic, qos },
-    //             };
-    //             debug!("Creating plug: {:?}", &plug);
-    //             // self.input_plugs.push(plug);
-    //             Ok(plug)
-    //         }
-    //         Err(e) => {
-    //             error!("Error subscribing to topic {}: {:?}", &topic, e);
-    //             Err(())
-    //         }
-    //     }
-    // }
-
-    // pub fn create_output_plug(
-    //     &self,
-    //     name: &str,
-    //     qos: Option<i32>,
-    //     retain: Option<bool>,
-    //     override_topic: Option<&str>,
-    // ) -> Result<PlugDefinition, ()> {
-    //     let name = String::from(name);
-    //     let topic =
-    //         String::from(override_topic.unwrap_or(&build_topic(&self.role, &self.id, &name)));
-    //     let qos = qos.unwrap_or(1);
-    //     let retain = retain.unwrap_or(false);
-
-    //     let plug = PlugDefinition {
-    //         name,
-    //         topic,
-    //         qos,
-    //         retain,
-    //     };
-    //     debug!("Adding output plug: {:?}", &plug);
-    //     Ok(plug)
-    // }
-
     /// If a message is waiting return Plug Name, Message (String, Message)
     pub fn check_messages(&self) -> Option<(String, Message)> {
         if let Some(message) = self.receiver.try_iter().find_map(|m| m) {

--- a/base_agent/rs/src/lib.rs
+++ b/base_agent/rs/src/lib.rs
@@ -140,7 +140,7 @@ impl PlugOptionsBuilder {
                 tether_agent
                     .client
                     .subscribe(&final_topic, final_qos)
-                    .expect(&format!("failed to subscribe to topic {}", &final_topic));
+                    .expect("failed to subscribe!");
                 PlugDefinition::InputPlugDefinition(InputPlugDefinition {
                     common: PlugDefinitionCommon {
                         name: plug.common.name,
@@ -260,7 +260,7 @@ impl TetherAgentOptionsBuilder {
         };
 
         if self.auto_connect {
-            match agent.connect(self.username.clone(), self.password.clone()) {
+            match agent.connect(self.username, self.password) {
                 Ok(()) => Ok(agent),
                 Err(_) => Err(()),
             }
@@ -397,7 +397,7 @@ impl TetherAgent {
             PlugDefinition::OutputPlugDefinition(definition) => {
                 let PlugDefinitionCommon { topic, qos, .. } = &definition.common;
                 let message = MessageBuilder::new()
-                    .topic(*&topic)
+                    .topic(topic)
                     .payload(payload.unwrap_or(&[]))
                     .retained(definition.retain)
                     .qos(*qos)

--- a/base_agent/rs/src/lib.rs
+++ b/base_agent/rs/src/lib.rs
@@ -42,7 +42,7 @@ pub struct OutputPlugOptions {
 }
 
 /// This is the definition of an Input or Output Plug
-/// You should never use this directly; call finalize()
+/// You should never use this directly; call build()
 /// to get a usable Plug
 pub enum PlugOptionsBuilder {
     InputPlugOptions(InputPlugOptions),
@@ -125,7 +125,7 @@ impl PlugOptionsBuilder {
         }
     }
 
-    pub fn finalize(self, tether_agent: &TetherAgent) -> PlugDefinition {
+    pub fn build(self, tether_agent: &TetherAgent) -> PlugDefinition {
         match self {
             Self::InputPlugOptions(plug) => {
                 let final_topic = plug
@@ -232,7 +232,7 @@ impl TetherAgentOptionsBuilder {
         self
     }
 
-    pub fn finalize(self) -> Result<TetherAgent, ()> {
+    pub fn build(self) -> Result<TetherAgent, ()> {
         let broker_host = self.host.clone().unwrap_or("localhost".into());
         let broker_port = self.port.unwrap_or(1883);
 

--- a/base_agent/rs/src/lib.rs
+++ b/base_agent/rs/src/lib.rs
@@ -28,7 +28,7 @@ pub struct OutputPlug {
 /// This is the definition of an Input or Output Plug
 /// You should never use this directly; call finalize()
 /// to get a usable Plug
-enum PlugOptionsBuilder {
+pub enum PlugOptionsBuilder {
     InputPlugDefinition(InputPlug),
     OutputPlugDefinition(OutputPlug),
 }


### PR DESCRIPTION
The idea is to make the creation of Agents, InputPlugs and OutputPlugs much easier. 

Using this new pattern (and new API), the library-user (developer) only needs to remember very few parameters when calling "create"/"new" functions - typically just 1 - in the default cases.

## Agent Creation

### Using defaults only
For example, creating an agent with default options - and then connecting - used to require this:
```rs
let tether_agent = TetherAgent::new("RustDemoAgent", None, None);
tether_agent.connect(None,None).expect("failed to connect");
```
The developer has to remember to include all the `None`s if they want to use the defaults.

With the options builder pattern, it could be as simple as:
```rs
let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
        .build()
        .unwrap();
```
The `build()` function is new, and so is the need to `unwrap` (or `expect`, or `match`) on the `Result`, but this is a common pattern for Rust APIs (see https://rust-unofficial.github.io/patterns/patterns/creational/builder.html). The only parameter required is the "agent role" - as it should be, by default. This version of the library also includes **automatically connecting at the same time** - a feature that can be turned off but is convenient to have by default.

### Customising, optionally
If non-default options need to be applied, the developer no longer has to remember which parameters to provide with `Some`; they only need to know the functions to call.

Here is an example from the original API, where a custom Agent ID, username, password and hostname are being applied:
```rs
let tether_agent = TetherAgent::new("RustDemoAgent", Some("customID".into()), Some("tether-io.dev".into()));
tether_agent.connect(Some("myUsername".into()), Some("myPassword".into()))
```
Notice how you need to remember to put some options in the `TetherAgent::new` call, and some in the `.connect` call. The order matters, too.

Here's the same using the proposed new API:
```rs
 let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
        .id("customID")
        .username("myUsername")
        .password("myPassword")
        .host("tether-io.dev")
        .build()
        .expect("failed to init Tether agent");
```
All of the function calls following `::new` and up to `.build` are entirely optional. The order doesn't matter. And since connection is handled automatically, it makes sense to allow the username and password to be set here too - no special separate step.

If desired, the user can also add `.auto_connect(false)`, and the Base Agent will print a warning that connection must be done manually - this is done by calling `.connect` explicitly.

## Plug Creation
A similar approach has been taken with InputPlug and OutputPlug creation. 

In the original API, both types of Plugs had to be created by calling methods on the `TetherAgent` instance - this was done partly to allow automatic creation of topic strings (in the case of Output Plugs), but also to ensure that subscription happened on the MQTT Client which was owned by the TetherAgent (in the case of Input Plugs).

In this proposal, plug definitions are created separately, although a reference to the Tether Agent instance is always included in the final step (`build`).

### Using defaults only
Here is an example of creating an Input and an Output Plug using the original API:
```rs
let input_one = tether_agent.create_input_plug("one", None, None).unwrap();
let output_custom = tether_agent.create_output_plug("custom", None, None, None).unwrap();
```
Again, notice all the `None`s that must be included. And the number of them differs, too!

Now the same, in the proposed new API:
```rs
let input_one = PlugOptionsBuilder::create_input("one").build(&tether_agent)
let output_custom = PlugOptionsBuilder::create_output("custom").build(&tether_agent);
```
Apart from the `build` step and the slightly more awkward namespacing, this requires only the minimum parameters, i.e. the "plug name". And `build` in the case of the Input Plug handles the `client.subscribe` step internally.

### Customising, optionally
There are plenty of ways that we might want to use non-defaults for Plugs - QOS, retain (Output only), custom topics, etc.

In the original API, you needed to remember to provide the relevant `Some`s, in the correct order, e.g.:
```rs
let input_one = tether_agent.create_input_plug("one", Some(2), Some("SomeRole/SomeID/one").unwrap();
let output_one = tether_agent.create_output_plug("one", Some(0), Some(false), Some("SomeRole/AnotherID/values").unwrap();
```
Notice how the order and number of parameters is hard to remember: _name, optional-QOS, optional-override-topic_ for Input Plugs and _name, optional-QOS, optional-override-topic_ for Output Plugs. Potentially confusing.

It gets even worse every time we add more optional options!

Compare the new proposed API, for the same customisation as above:
```rs
let input_one = PlugOptionsBuilder::create_input("one")
  .qos(2)
  .topic("SomeRole/SomeID/one")
  .build(&tether_agent);
let output_one = PlugOptionsBuilder::create_output("one"
  .topic("SomeRole/AnotherID/values")
  .retain(false)
  .qos(0)
  .build(&tether_agent)
```
The order doesn't matter, and all of the functions between `::create_input` / `::create_output` and `.build` are optional. The developer only needs to know about functions, not multiple parameters in the "create" step.