### PR TITLE
Tether Utils as a library

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,19 @@
   "version": "0.2.0",
   "configurations": [
   {
+    "type": "lldb",
+    "request": "launch",
+    "name": "Debug Tether Utils",
+    // "cwd": "${workspaceFolder}/utilities/tether-utils",
+    "cargo": {
+      "args": [
+        "build",
+        "--manifest-path", "${workspaceFolder}/utilities/tether-utils/Cargo.toml"
+      ]
+    },
+    "args": ["topics"]
+  },
+  {
     "name": "Launch NodeJS example",
     "program": "${workspaceFolder}/examples/nodejs/index.js",
     "request": "launch",

--- a/base_agent/rs/examples/error_handling.rs
+++ b/base_agent/rs/examples/error_handling.rs
@@ -1,5 +1,5 @@
 use env_logger::{Builder, Env};
-use log::{debug, error, info, warn};
+use log::*;
 use serde::Serialize;
 use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
 

--- a/base_agent/rs/examples/subscribe_publish_threaded.rs
+++ b/base_agent/rs/examples/subscribe_publish_threaded.rs
@@ -38,6 +38,7 @@ fn main() {
 
     println!("Set up tether agent OK");
 
+    #[allow(unused_assignments)]
     let mut output_plug = None;
 
     // Here we call .lock() because it is OK to block while "setting up", connecting

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -678,6 +678,8 @@ dependencies = [
 [[package]]
 name = "tether-agent"
 version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0716c6da7b21eef6cd83a3cf391f63700080d56f74ce9ec796972c535cddd06b"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -690,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "tether-utils"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "circular-buffer",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
 name = "tether-utils"
 version = "0.3.2"
 dependencies = [
+ "anyhow",
  "clap",
  "ctrlc",
  "env_logger",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -678,8 +678,6 @@ dependencies = [
 [[package]]
 name = "tether-agent"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0716c6da7b21eef6cd83a3cf391f63700080d56f74ce9ec796972c535cddd06b"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -677,7 +677,9 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.8.3"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0716c6da7b21eef6cd83a3cf391f63700080d56f74ce9ec796972c535cddd06b"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "circular-buffer"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5887fa83bbf76a5cf15915add06c187cfc9d00f2ae9aa1f33d108a02ba7af345"
+
+[[package]]
 name = "clap"
 version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +693,7 @@ name = "tether-utils"
 version = "0.3.2"
 dependencies = [
  "anyhow",
+ "circular-buffer",
  "clap",
  "ctrlc",
  "env_logger",

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -13,7 +13,8 @@ name = "tether"
 
 
 [dependencies]
-tether-agent = { path = "../../base_agent/rs", version = "0.8.3"}
+# tether-agent = { path = "../../base_agent/rs", version = "0.8.3"}
+tether-agent = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 rmp-serde = "1.1.1"

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -13,8 +13,8 @@ name = "tether"
 
 
 [dependencies]
-# tether-agent = { path = "../../base_agent/rs", version = "0.8.3"}
-tether-agent = "0.8.3"
+tether-agent = { path = "../../base_agent/rs"}
+# tether-agent = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 rmp-serde = "1.1.1"

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -22,3 +22,4 @@ env_logger = "0.7"
 rmpv = { version = "0.4", features = ["with-serde"] }
 clap = { version = "4.1.1", features = ["derive"] }
 ctrlc = "3.4.0"
+anyhow = "1.0.71"

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-utils"
 description = "Utilities for Tether Systems"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"
@@ -13,8 +13,8 @@ name = "tether"
 
 
 [dependencies]
-tether-agent = { path = "../../base_agent/rs"}
-# tether-agent = "0.8.3"
+# tether-agent = { path = "../../base_agent/rs"}
+tether-agent = "0.8.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 rmp-serde = "1.1.1"

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"
 
+[lib]
+
 [[bin]]
 name = "tether"
-path = "./src/main.rs"
+
 
 [dependencies]
 tether-agent = { path = "../../base_agent/rs", version = "0.8.3"}

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -23,3 +23,4 @@ rmpv = { version = "0.4", features = ["with-serde"] }
 clap = { version = "4.1.1", features = ["derive"] }
 ctrlc = "3.4.0"
 anyhow = "1.0.71"
+circular-buffer = "0.1.1"

--- a/utilities/tether-utils/README.md
+++ b/utilities/tether-utils/README.md
@@ -15,7 +15,7 @@ This CLI utility tool, written in Rust, provides a single binary with subcommand
 There are always **two parts** to the CLI command
 
 - The main command `tether`
-  - Followed by optional parameters _for general configuration_ such as `--tether.host` or `--loglevel`
+  - Followed by optional parameters _for general configuration_ such as `--host` or `--loglevel`
 - The subcommand `receive`, `send`, `topics`, `record` or `playback`
   - Followed by optional paramaters _relating to the specific subcommand_
 
@@ -24,7 +24,7 @@ There are always **two parts** to the CLI command
 Here's an example of using the `receive` subcommand but specifying some non-default details for the MQTT Broker, and a non-default topic:
 
 ```
-tether --tether.host 10.0.0.1 --tether.username myUserName --tether.password myPaSsWorD! receive --topic +/+/someSpecificPlug
+tether --host 10.0.0.1 --username myUserName --password myPaSsWorD! receive --topic +/+/someSpecificPlug
 ```
 
 ## Installation

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -1,0 +1,25 @@
+use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
+
+fn demo_receive() {
+    let tether_agent = TetherAgentOptionsBuilder::new("demo")
+        .build()
+        .expect("failed to init/connect Tether Agent");
+
+    let input_plug = PlugOptionsBuilder::create_input("dummyData")
+        .build(&tether_agent)
+        .expect("failed to create input plug");
+
+    loop {
+        while let Some((plug_name, message)) = &tether_agent.check_messages() {
+            println!("RECEIVE: got message on topic \"{}\"", message.topic());
+        }
+    }
+}
+
+fn main() {
+    println!(
+        "This example shows how the tether-utils library can be used programmatically, 
+    i.e. not from the CLI"
+    );
+    demo_receive();
+}

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -35,7 +35,8 @@ fn demo_send() {
     let options = SendOptions {
         plug_name: "dummyData".into(),
         plug_topic: None,
-        custom_message: None,
+        message_payload_json: None,
+        use_dummy_data: true,
     };
 
     loop {

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -7,7 +7,7 @@ use tether_utils::{
     tether_receive::{receive, ReceiveOptions},
     tether_record::{RecordOptions, TetherRecordUtil},
     tether_send::{send, SendOptions},
-    tether_topics::{subscribe, Insights, TopicOptions},
+    tether_topics::{Insights, TopicOptions},
 };
 
 fn demo_receive() {
@@ -55,13 +55,11 @@ fn demo_topics() {
         subscribe_topic: "#".into(),
     };
 
-    let mut insights = Insights::new();
-
-    let input = subscribe(&options, &tether_agent).expect("failed to subscribe");
+    let mut insights = Insights::new(&options);
 
     loop {
-        if insights.check_for_updates(&input, &tether_agent) {
-            println!("Insights update: {:#?}", insights);
+        if insights.check_for_updates(&tether_agent) {
+            println!("Insights update: \n{}", insights);
 
             println!(
                 "counted {} topics, {} roles, {} ids and {} plugs",
@@ -145,7 +143,7 @@ fn main() {
     );
     println!("Press Ctrl+C to stop");
 
-    let mut env_builder = Builder::from_env(Env::default().default_filter_or("debug"));
+    let mut env_builder = Builder::from_env(Env::default().default_filter_or("info"));
     env_builder.init();
 
     let handles = vec![

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -64,6 +64,19 @@ pub fn demo_topics() {
     loop {
         if insights.check_for_updates(&input, &tether_agent) {
             println!("Insights update: {:#?}", insights);
+            let Insights {
+                topics,
+                roles,
+                ids,
+                plugs,
+            } = &insights;
+            println!(
+                "counted {} topics, {} roles, {} ids and {} plugs",
+                topics.len(),
+                roles.len(),
+                ids.len(),
+                plugs.len()
+            );
         }
     }
 }

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -1,7 +1,7 @@
 use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
 
 fn demo_receive() {
-    let tether_agent = TetherAgentOptionsBuilder::new("demo")
+    let tether_agent = TetherAgentOptionsBuilder::new("demoReceive")
         .build()
         .expect("failed to init/connect Tether Agent");
 
@@ -9,10 +9,38 @@ fn demo_receive() {
         .build(&tether_agent)
         .expect("failed to create input plug");
 
+    let mut count = 0;
+
     loop {
         while let Some((plug_name, message)) = &tether_agent.check_messages() {
-            println!("RECEIVE: got message on topic \"{}\"", message.topic());
+            count += 1;
+            println!(
+                "RECEIVE: got message#{} on topic \"{}\"",
+                count,
+                message.topic()
+            );
         }
+    }
+}
+
+fn demo_send() {
+    let tether_agent = TetherAgentOptionsBuilder::new("demoSend")
+        .build()
+        .expect("failed to init/connect Tether Agent");
+
+    let output_plug = PlugOptionsBuilder::create_output("dummyData")
+        .build(&tether_agent)
+        .expect("failed to create output plug");
+
+    let mut count = 0;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        count += 1;
+        println!("SEND: sending message #{}", count);
+        tether_agent
+            .encode_and_publish(&output_plug, count)
+            .expect("failed to publish");
     }
 }
 
@@ -21,5 +49,17 @@ fn main() {
         "This example shows how the tether-utils library can be used programmatically, 
     i.e. not from the CLI"
     );
-    demo_receive();
+    println!("Press Ctrl+C to stop");
+
+    let mut handles = Vec::new();
+    handles.push(std::thread::spawn(move || {
+        demo_receive();
+    }));
+    handles.push(std::thread::spawn(move || {
+        demo_send();
+    }));
+
+    for handle in handles {
+        handle.join().expect("failed to join handle");
+    }
 }

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -79,14 +79,14 @@ fn demo_playback() {
         .build()
         .expect("failed to init/connect Tether Agent");
 
-    let player = TetherPlaybackUtil::new(options, tether_agent);
+    let player = TetherPlaybackUtil::new(options);
     let stop_request_tx = player.get_stop_tx();
 
     let start_time = SystemTime::now();
 
     let handles = vec![
         spawn(move || {
-            player.start();
+            player.start(&tether_agent);
         }),
         spawn(move || {
             let mut time_to_end = false;

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -1,7 +1,7 @@
 use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
 use tether_utils::{
     tether_send::{send, SendOptions},
-    tether_topics::{topics, TopicOptions},
+    tether_topics::{subscribe, Insights, TopicOptions},
 };
 
 fn demo_receive() {
@@ -56,9 +56,16 @@ pub fn demo_topics() {
     let options = TopicOptions {
         subscribe_topic: "#".into(),
     };
-    topics(&options, &tether_agent, |res| {
-        println!("TOPICS: update: {}", res);
-    });
+
+    let mut insights = Insights::new();
+
+    let input = subscribe(&options, &tether_agent).expect("failed to subscribe");
+
+    loop {
+        if insights.check_for_updates(&input, &tether_agent) {
+            println!("Insights update: {:#?}", insights);
+        }
+    }
 }
 
 fn main() {

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -51,9 +51,7 @@ fn demo_topics() {
         .build()
         .expect("failed to init/connect Tether Agent");
 
-    let options = TopicOptions {
-        subscribe_topic: "#".into(),
-    };
+    let options = TopicOptions { topic: "#".into() };
 
     let mut insights = Insights::new(&options, &tether_agent);
 
@@ -122,7 +120,7 @@ fn demo_record() {
         file_base_path: "./".into(),
         file_base_name: "recording".into(),
         file_no_timestamp: false,
-        subscribe_topic: "#".into(),
+        topic: "#".into(),
         timing_nonzero_start: false,
         timing_delay: None,
         timing_duration: None,

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -129,7 +129,7 @@ fn demo_record() {
         ignore_ctrl_c: true, // this is important for programmatic use
     };
 
-    let recorder = TetherRecordUtil::new(options, tether_agent);
+    let recorder = TetherRecordUtil::new(options);
     let stop_request_tx = recorder.get_stop_tx();
 
     let start_time = SystemTime::now();
@@ -152,7 +152,7 @@ fn demo_record() {
             println!("...Bye");
         }),
         spawn(move || {
-            recorder.start_recording();
+            recorder.start_recording(&tether_agent);
         }),
     ];
 

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -55,19 +55,13 @@ fn demo_topics() {
         subscribe_topic: "#".into(),
     };
 
-    let mut insights = Insights::new(&options);
+    let mut insights = Insights::new(&options, &tether_agent);
 
     loop {
-        if insights.check_for_updates(&tether_agent) {
-            println!("Insights update: \n{}", insights);
-
-            println!(
-                "counted {} topics, {} roles, {} ids and {} plugs",
-                insights.topics().len(),
-                insights.roles().len(),
-                insights.ids().len(),
-                insights.plugs().len()
-            );
+        while let Some((_plug_name, message)) = tether_agent.check_messages() {
+            if insights.update(&message) {
+                println!("TOPICS: Insights update: \n{}", insights);
+            }
         }
     }
 }

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -1,7 +1,7 @@
 use std::{thread::spawn, time::SystemTime};
 
 use env_logger::{Builder, Env};
-use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
+use tether_agent::TetherAgentOptionsBuilder;
 use tether_utils::{
     tether_playback::{playback, PlaybackOptions},
     tether_receive::{receive, ReceiveOptions},
@@ -62,18 +62,13 @@ fn demo_topics() {
     loop {
         if insights.check_for_updates(&input, &tether_agent) {
             println!("Insights update: {:#?}", insights);
-            let Insights {
-                topics,
-                roles,
-                ids,
-                plugs,
-            } = &insights;
+
             println!(
                 "counted {} topics, {} roles, {} ids and {} plugs",
-                topics.len(),
-                roles.len(),
-                ids.len(),
-                plugs.len()
+                insights.topics().len(),
+                insights.roles().len(),
+                insights.ids().len(),
+                insights.plugs().len()
             );
         }
     }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -83,14 +83,11 @@ fn main() {
         Commands::Send(options) => tether_send::send(options, &tether_agent)
             .unwrap_or_else(|e| error!("Failed to send: {}", e)),
         Commands::Topics(options) => {
-            let mut insights = tether_topics::Insights::new();
-
-            let input =
-                tether_topics::subscribe(options, &tether_agent).expect("failed to subscribe");
+            let mut insights = tether_topics::Insights::new(&options);
 
             loop {
-                if insights.check_for_updates(&input, &tether_agent) {
-                    info!("Insights update: {:#?}", insights);
+                if insights.check_for_updates(&tether_agent) {
+                    info!("Insights update: \n{}", insights);
                 }
             }
         }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -98,8 +98,8 @@ fn main() {
             player.start(&tether_agent);
         }
         Commands::Record(options) => {
-            let recorder = tether_record::TetherRecordUtil::new(options.clone(), tether_agent);
-            recorder.start_recording();
+            let recorder = tether_record::TetherRecordUtil::new(options.clone());
+            recorder.start_recording(&tether_agent);
         }
     }
 }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -3,20 +3,8 @@ use log::{debug, error, warn};
 
 use clap::{Parser, Subcommand};
 
-mod tether_playback;
-mod tether_receive;
-mod tether_record;
-mod tether_send;
-mod tether_topics;
-
 use tether_agent::TetherAgentOptionsBuilder;
-use tether_playback::PlaybackOptions;
-use tether_receive::{receive, ReceiveOptions};
-use tether_record::RecordOptions;
-use tether_send::{send, SendOptions};
-use tether_topics::{topics, TopicOptions};
-
-use crate::{tether_playback::playback, tether_record::record};
+use tether_utils::*;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -50,11 +38,11 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    Receive(ReceiveOptions),
-    Send(SendOptions),
-    Topics(TopicOptions),
-    Playback(PlaybackOptions),
-    Record(RecordOptions),
+    Receive(tether_receive::ReceiveOptions),
+    Send(tether_send::SendOptions),
+    Topics(tether_topics::TopicOptions),
+    Playback(tether_playback::PlaybackOptions),
+    Record(tether_record::RecordOptions),
 }
 
 fn main() {
@@ -82,10 +70,10 @@ fn main() {
         });
 
     match &cli.command {
-        Commands::Receive(options) => receive(options, &tether_agent),
-        Commands::Send(options) => send(options, &tether_agent),
-        Commands::Topics(options) => topics(options, &tether_agent),
-        Commands::Playback(options) => playback(options, &tether_agent),
-        Commands::Record(options) => record(options, &tether_agent),
+        Commands::Receive(options) => tether_receive::receive(options, &tether_agent),
+        Commands::Send(options) => tether_send::send(options, &tether_agent),
+        Commands::Topics(options) => tether_topics::topics(options, &tether_agent),
+        Commands::Playback(options) => tether_playback::playback(options, &tether_agent),
+        Commands::Record(options) => tether_record::record(options, &tether_agent),
     }
 }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -83,7 +83,7 @@ fn main() {
         Commands::Send(options) => tether_send::send(options, &tether_agent)
             .unwrap_or_else(|e| error!("Failed to send: {}", e)),
         Commands::Topics(options) => {
-            let mut insights = tether_topics::Insights::new(&options, &tether_agent);
+            let mut insights = tether_topics::Insights::new(options, &tether_agent);
 
             loop {
                 while let Some((_plug_name, message)) = tether_agent.check_messages() {

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -95,6 +95,9 @@ fn main() {
             }
         }
         Commands::Playback(options) => tether_playback::playback(options, &tether_agent),
-        Commands::Record(options) => tether_record::record(options, &tether_agent),
+        Commands::Record(options) => {
+            let recorder = tether_record::TetherRecordUtil::new(options, tether_agent);
+            recorder.start_recording();
+        }
     }
 }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -12,24 +12,24 @@ pub struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    #[arg(long = "tether.host", default_value_t=String::from("localhost"))]
+    #[arg(long = "host", default_value_t=String::from("localhost"))]
     pub tether_host: String,
 
-    #[arg(long = "tether.port", default_value_t = 1883)]
+    #[arg(long = "port", default_value_t = 1883)]
     pub tether_port: u16,
 
-    #[arg(long = "tether.username", default_value_t=String::from("tether"))]
+    #[arg(long = "username", default_value_t=String::from("tether"))]
     pub tether_username: String,
 
-    #[arg(long = "tether.password", default_value_t=String::from("sp_ceB0ss!"))]
+    #[arg(long = "password", default_value_t=String::from("sp_ceB0ss!"))]
     pub tether_password: String,
 
     /// Role to use for any auto-generated topics on publish
-    #[arg(long = "tether.role", default_value_t=String::from("utils"))]
+    #[arg(long = "role", default_value_t=String::from("utils"))]
     pub tether_role: String,
 
     /// ID/Group to use for any auto-generated topics on publish
-    #[arg(long = "tether.id", default_value_t=String::from("any"))]
+    #[arg(long = "id", default_value_t=String::from("any"))]
     pub tether_id: String,
 
     #[arg(long = "loglevel",default_value_t=String::from("info"))]

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -94,8 +94,8 @@ fn main() {
             }
         }
         Commands::Playback(options) => {
-            let player = TetherPlaybackUtil::new(options.clone(), tether_agent);
-            player.start();
+            let player = TetherPlaybackUtil::new(options.clone());
+            player.start(&tether_agent);
         }
         Commands::Record(options) => {
             let recorder = tether_record::TetherRecordUtil::new(options.clone(), tether_agent);

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -4,7 +4,7 @@ use log::*;
 use clap::{Parser, Subcommand};
 
 use tether_agent::TetherAgentOptionsBuilder;
-use tether_utils::*;
+use tether_utils::{tether_playback::TetherPlaybackUtil, *};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -93,9 +93,12 @@ fn main() {
                 }
             }
         }
-        Commands::Playback(options) => tether_playback::playback(options, &tether_agent),
+        Commands::Playback(options) => {
+            let player = TetherPlaybackUtil::new(options.clone(), tether_agent);
+            player.start();
+        }
         Commands::Record(options) => {
-            let recorder = tether_record::TetherRecordUtil::new(options, tether_agent);
+            let recorder = tether_record::TetherRecordUtil::new(options.clone(), tether_agent);
             recorder.start_recording();
         }
     }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -82,9 +82,18 @@ fn main() {
         }
         Commands::Send(options) => tether_send::send(options, &tether_agent)
             .unwrap_or_else(|e| error!("Failed to send: {}", e)),
-        Commands::Topics(options) => tether_topics::topics(options, &tether_agent, |summary| {
-            info!("Insights parsed update:\n {}", summary);
-        }),
+        Commands::Topics(options) => {
+            let mut insights = tether_topics::Insights::new();
+
+            let input =
+                tether_topics::subscribe(options, &tether_agent).expect("failed to subscribe");
+
+            loop {
+                if insights.check_for_updates(&input, &tether_agent) {
+                    info!("Insights update: {:#?}", insights);
+                }
+            }
+        }
         Commands::Playback(options) => tether_playback::playback(options, &tether_agent),
         Commands::Record(options) => tether_record::record(options, &tether_agent),
     }

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -83,11 +83,13 @@ fn main() {
         Commands::Send(options) => tether_send::send(options, &tether_agent)
             .unwrap_or_else(|e| error!("Failed to send: {}", e)),
         Commands::Topics(options) => {
-            let mut insights = tether_topics::Insights::new(&options);
+            let mut insights = tether_topics::Insights::new(&options, &tether_agent);
 
             loop {
-                if insights.check_for_updates(&tether_agent) {
-                    info!("Insights update: \n{}", insights);
+                while let Some((_plug_name, message)) = tether_agent.check_messages() {
+                    if insights.update(&message) {
+                        info!("Insights update: \n{}", insights);
+                    }
                 }
             }
         }

--- a/utilities/tether-utils/src/lib.rs
+++ b/utilities/tether-utils/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod tether_playback;
+pub mod tether_receive;
+pub mod tether_record;
+pub mod tether_send;
+pub mod tether_topics;

--- a/utilities/tether-utils/src/tether_playback.rs
+++ b/utilities/tether-utils/src/tether_playback.rs
@@ -35,6 +35,18 @@ pub struct PlaybackOptions {
     pub ignore_ctrl_c: bool,
 }
 
+impl Default for PlaybackOptions {
+    fn default() -> Self {
+        PlaybackOptions {
+            file_path: "./demo.json".into(),
+            override_topic: None,
+            loop_count: 1,
+            loop_infinite: false,
+            ignore_ctrl_c: false,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SimulationMessage {

--- a/utilities/tether-utils/src/tether_playback.rs
+++ b/utilities/tether-utils/src/tether_playback.rs
@@ -54,11 +54,10 @@ pub struct TetherPlaybackUtil {
     stop_request_tx: mpsc::Sender<bool>,
     stop_request_rx: mpsc::Receiver<bool>,
     options: PlaybackOptions,
-    tether_agent: TetherAgent,
 }
 
 impl TetherPlaybackUtil {
-    pub fn new(options: PlaybackOptions, tether_agent: TetherAgent) -> Self {
+    pub fn new(options: PlaybackOptions) -> Self {
         info!("Tether Playback Utility: initialise");
 
         let (tx, rx) = mpsc::channel();
@@ -66,7 +65,6 @@ impl TetherPlaybackUtil {
             stop_request_tx: tx,
             stop_request_rx: rx,
             options,
-            tether_agent,
         }
     }
 
@@ -74,7 +72,7 @@ impl TetherPlaybackUtil {
         self.stop_request_tx.clone()
     }
 
-    pub fn start(&self) {
+    pub fn start(&self, tether_agent: &TetherAgent) {
         info!("Tether Playback Utility: start playback");
 
         if let Some(t) = &self.options.override_topic {
@@ -117,7 +115,7 @@ impl TetherPlaybackUtil {
                 }
                 if parse_json_rows(
                     &self.options.file_path,
-                    &self.tether_agent,
+                    &tether_agent,
                     &self.options.override_topic,
                     &self.stop_request_rx,
                 ) {

--- a/utilities/tether-utils/src/tether_playback.rs
+++ b/utilities/tether-utils/src/tether_playback.rs
@@ -1,4 +1,8 @@
-use std::{fs::File, io::BufReader};
+use std::{
+    fs::File,
+    io::BufReader,
+    sync::mpsc::{self, Receiver},
+};
 
 use clap::Args;
 use log::{debug, info, warn};
@@ -7,22 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tether_agent::TetherAgent;
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SimulationMessage {
-    pub r#type: String,
-    pub data: Vec<u8>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SimulationRow {
-    pub topic: String,
-    pub message: SimulationMessage,
-    pub delta_time: u64,
-}
-
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct PlaybackOptions {
     /// Specify the full path to the JSON file containing recorded messages
     #[arg(long = "file.path", default_value_t=String::from("./demo.json"))]
@@ -39,65 +28,164 @@ pub struct PlaybackOptions {
     /// Flag to enable infinite looping for playback (ignore loops.count if enabled)
     #[arg(long = "loops.infinite")]
     pub loop_infinite: bool,
+
+    /// Flag to disable registration of Ctrl+C handler - this is usually necessary
+    /// when using the utility programmatically (i.e. not via CLI)
+    #[arg(long = "ignoreCtrlC")]
+    pub ignore_ctrl_c: bool,
 }
 
-pub fn playback(options: &PlaybackOptions, tether_agent: &TetherAgent) {
-    info!("Tether Playback Utility");
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulationMessage {
+    pub r#type: String,
+    pub data: Vec<u8>,
+}
 
-    if let Some(t) = &options.override_topic {
-        warn!("Override topic provided; ALL topics in JSON entries will be ignored and replaced with \"{}\"",t);
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulationRow {
+    pub topic: String,
+    pub message: SimulationMessage,
+    pub delta_time: u64,
+}
+
+pub struct TetherPlaybackUtil {
+    stop_request_tx: mpsc::Sender<bool>,
+    stop_request_rx: mpsc::Receiver<bool>,
+    options: PlaybackOptions,
+    tether_agent: TetherAgent,
+}
+
+impl TetherPlaybackUtil {
+    pub fn new(options: PlaybackOptions, tether_agent: TetherAgent) -> Self {
+        info!("Tether Playback Utility: initialise");
+
+        let (tx, rx) = mpsc::channel();
+        TetherPlaybackUtil {
+            stop_request_tx: tx,
+            stop_request_rx: rx,
+            options,
+            tether_agent,
+        }
     }
 
-    if options.loop_infinite {
-        loop {
+    pub fn get_stop_tx(&self) -> mpsc::Sender<bool> {
+        self.stop_request_tx.clone()
+    }
+
+    pub fn start(&self) {
+        info!("Tether Playback Utility: start playback");
+
+        if let Some(t) = &self.options.override_topic {
+            warn!("Override topic provided; ALL topics in JSON entries will be ignored and replaced with \"{}\"",t);
+        }
+
+        let stop_from_key = self.stop_request_tx.clone();
+
+        if !self.options.ignore_ctrl_c {
             warn!("Infinite loops requested; Press Ctr+C to stop");
-            parse_json_rows(&options.file_path, tether_agent, &options.override_topic);
-        }
-    } else {
-        let mut count = 0;
-        while count < options.loop_count {
-            count += 1;
-            info!(
-                "Finite loops requested: starting loop {}/{}",
-                count, options.loop_count
+            ctrlc::set_handler(move || {
+                // should_stop_clone.store(true, Ordering::Relaxed);
+                stop_from_key
+                    .send(true)
+                    .expect("failed to send stop from key");
+                warn!("received Ctrl+C! 2");
+            })
+            .expect("Error setting Ctrl-C handler");
+        } else {
+            warn!(
+                "No Ctrl+C handler set; you may need to kill this process manually, PID: {}",
+                std::process::id()
             );
-            parse_json_rows(&options.file_path, tether_agent, &options.override_topic);
         }
-        info!("All {} loops completed", options.loop_count);
+
+        let mut finished = false;
+
+        let mut count = 0;
+
+        while !finished {
+            count += 1;
+            if !finished {
+                if !self.options.loop_infinite {
+                    info!(
+                        "Finite loops requested: starting loop {}/{}",
+                        count, self.options.loop_count
+                    );
+                } else {
+                    info!("Infinite loops requested; starting loop {}", count);
+                }
+                if parse_json_rows(
+                    &self.options.file_path,
+                    &self.tether_agent,
+                    &self.options.override_topic,
+                    &self.stop_request_rx,
+                ) {
+                    warn!("Early exit; finish now");
+                    finished = true;
+                }
+            }
+            if !self.options.loop_infinite && count >= self.options.loop_count {
+                info!("All {} loops completed", &self.options.loop_count);
+                finished = true;
+            }
+        }
     }
 }
 
-fn parse_json_rows(filename: &str, tether_agent: &TetherAgent, override_topic: &Option<String>) {
+fn parse_json_rows(
+    filename: &str,
+    tether_agent: &TetherAgent,
+    override_topic: &Option<String>,
+    should_stop_rx: &Receiver<bool>,
+) -> bool {
     let file = File::open(filename).unwrap_or_else(|_| panic!("failed to open file {}", filename));
     let reader = BufReader::new(file);
     let deserializer = serde_json::Deserializer::from_reader(reader);
-    // let mut rows: Vec<T> = vec![];
     let mut iterator = deserializer.into_iter::<Vec<Value>>();
     let top_level_array: Vec<Value> = iterator.next().unwrap().unwrap();
-    for row_value in top_level_array.into_iter() {
-        let row: SimulationRow =
-            serde_json::from_value(row_value).expect("failed to decode JSON row");
 
-        let SimulationRow {
-            topic,
-            message,
-            delta_time,
-        } = &row;
+    let mut finished = false;
+    let mut early_exit = false;
+    // let rows = top_level_array.into_iter();
 
-        let payload = &message.data;
+    let mut index = 0;
 
-        debug!("Sleeping {}ms ...", delta_time);
-        std::thread::sleep(std::time::Duration::from_millis(*delta_time));
+    while !finished {
+        while let Ok(_should_stop) = should_stop_rx.try_recv() {
+            early_exit = true;
+            finished = true;
+        }
+        if let Some(row_value) = top_level_array.get(index) {
+            let row: SimulationRow =
+                serde_json::from_value(row_value.clone()).expect("failed to decode JSON row");
 
-        let topic = match &override_topic {
-            Some(t) => String::from(t),
-            None => String::from(topic),
-        };
+            let SimulationRow {
+                topic,
+                message,
+                delta_time,
+            } = &row;
 
-        tether_agent
-            .publish_raw(&topic, payload, None, None)
-            .expect("failed to publish");
+            let payload = &message.data;
 
-        debug!("Got row {:?}", row);
+            if !finished {
+                debug!("Sleeping {}ms ...", delta_time);
+                std::thread::sleep(std::time::Duration::from_millis(*delta_time));
+                let topic = match &override_topic {
+                    Some(t) => String::from(t),
+                    None => String::from(topic),
+                };
+
+                tether_agent
+                    .publish_raw(&topic, payload, None, None)
+                    .expect("failed to publish");
+            }
+
+            debug!("Got row {:?}", row);
+        } else {
+            finished = true;
+        }
+        index += 1;
     }
+    early_exit
 }

--- a/utilities/tether-utils/src/tether_playback.rs
+++ b/utilities/tether-utils/src/tether_playback.rs
@@ -127,7 +127,7 @@ impl TetherPlaybackUtil {
                 }
                 if parse_json_rows(
                     &self.options.file_path,
-                    &tether_agent,
+                    tether_agent,
                     &self.options.override_topic,
                     &self.stop_request_rx,
                 ) {

--- a/utilities/tether-utils/src/tether_playback.rs
+++ b/utilities/tether-utils/src/tether_playback.rs
@@ -26,19 +26,19 @@ pub struct SimulationRow {
 pub struct PlaybackOptions {
     /// Specify the full path to the JSON file containing recorded messages
     #[arg(long = "file.path", default_value_t=String::from("./demo.json"))]
-    file_path: String,
+    pub file_path: String,
 
     /// Overide any original topics saved in the file, to use with every published message
     #[arg(long = "topic")]
-    override_topic: Option<String>,
+    pub override_topic: Option<String>,
 
     /// How many times to loop playback
     #[arg(long = "loops.count", default_value_t = 1)]
-    loop_count: usize,
+    pub loop_count: usize,
 
     /// Flag to enable infinite looping for playback (ignore loops.count if enabled)
     #[arg(long = "loops.infinite")]
-    loop_infinite: bool,
+    pub loop_infinite: bool,
 }
 
 pub fn playback(options: &PlaybackOptions, tether_agent: &TetherAgent) {

--- a/utilities/tether-utils/src/tether_playback.rs
+++ b/utilities/tether-utils/src/tether_playback.rs
@@ -5,9 +5,7 @@ use log::{debug, info, warn};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tether_agent::{TetherAgent, TetherAgentOptionsBuilder};
-
-use crate::{defaults, Cli};
+use tether_agent::TetherAgent;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -43,25 +41,17 @@ pub struct PlaybackOptions {
     loop_infinite: bool,
 }
 
-pub fn playback(cli: &Cli, options: &PlaybackOptions) {
+pub fn playback(options: &PlaybackOptions, tether_agent: &TetherAgent) {
     info!("Tether Playback Utility");
 
     if let Some(t) = &options.override_topic {
         warn!("Override topic provided; ALL topics in JSON entries will be ignored and replaced with \"{}\"",t);
     }
 
-    let tether_agent = TetherAgentOptionsBuilder::new(defaults::AGENT_ROLE)
-        .host(&cli.tether_host)
-        .port(cli.tether_port)
-        .username(&cli.tether_username)
-        .password(&cli.tether_password)
-        .build()
-        .expect("failed to connect Tether");
-
     if options.loop_infinite {
         loop {
             warn!("Infinite loops requested; Press Ctr+C to stop");
-            parse_json_rows(&options.file_path, &tether_agent, &options.override_topic);
+            parse_json_rows(&options.file_path, tether_agent, &options.override_topic);
         }
     } else {
         let mut count = 0;
@@ -71,7 +61,7 @@ pub fn playback(cli: &Cli, options: &PlaybackOptions) {
                 "Finite loops requested: starting loop {}/{}",
                 count, options.loop_count
             );
-            parse_json_rows(&options.file_path, &tether_agent, &options.override_topic);
+            parse_json_rows(&options.file_path, tether_agent, &options.override_topic);
         }
         info!("All {} loops completed", options.loop_count);
     }

--- a/utilities/tether-utils/src/tether_receive.rs
+++ b/utilities/tether-utils/src/tether_receive.rs
@@ -1,8 +1,6 @@
 use clap::Args;
 use log::{debug, error, info, warn};
-use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
-
-use crate::{defaults, Cli};
+use tether_agent::{PlugOptionsBuilder, TetherAgent};
 
 #[derive(Args)]
 pub struct ReceiveOptions {
@@ -11,19 +9,12 @@ pub struct ReceiveOptions {
     subscribe_topic: String,
 }
 
-pub fn receive(cli: &Cli, options: &ReceiveOptions) {
+pub fn receive(options: &ReceiveOptions, tether_agent: &TetherAgent) {
     info!("Tether Receive Utility");
-    let tether_agent = TetherAgentOptionsBuilder::new(defaults::AGENT_ROLE)
-        .host(&cli.tether_host)
-        .port(cli.tether_port)
-        .username(&cli.tether_username)
-        .password(&cli.tether_password)
-        .build()
-        .expect("failed to connect Tether");
 
     let _input = PlugOptionsBuilder::create_input("all")
         .topic(&options.subscribe_topic)
-        .build(&tether_agent)
+        .build(tether_agent)
         .expect("failed to create input plug");
 
     loop {

--- a/utilities/tether-utils/src/tether_receive.rs
+++ b/utilities/tether-utils/src/tether_receive.rs
@@ -6,7 +6,7 @@ use tether_agent::{mqtt::Message, PlugOptionsBuilder, TetherAgent};
 pub struct ReceiveOptions {
     /// Topic to subscribe; by default we recording everything
     #[arg(long = "topic", default_value_t=String::from("#"))]
-    subscribe_topic: String,
+    pub subscribe_topic: String,
 }
 
 pub fn receive(

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -97,7 +97,7 @@ impl TetherRecordUtil {
 
         let _input = PlugOptionsBuilder::create_input("all")
             .topic(&self.options.subscribe_topic)
-            .build(&tether_agent)
+            .build(tether_agent)
             .expect("failed to create input plug");
 
         let file_path = match &self.options.file_override_path {

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -58,11 +58,10 @@ pub struct TetherRecordUtil {
     stop_request_tx: mpsc::Sender<bool>,
     stop_request_rx: mpsc::Receiver<bool>,
     options: RecordOptions,
-    tether_agent: TetherAgent,
 }
 
 impl TetherRecordUtil {
-    pub fn new(options: RecordOptions, tether_agent: TetherAgent) -> Self {
+    pub fn new(options: RecordOptions) -> Self {
         info!("Tether Record Utility: initialise");
 
         let (tx, rx) = mpsc::channel();
@@ -71,19 +70,18 @@ impl TetherRecordUtil {
             stop_request_tx: tx,
             stop_request_rx: rx,
             options,
-            tether_agent,
         }
     }
 
     pub fn get_stop_tx(&self) -> mpsc::Sender<bool> {
         self.stop_request_tx.clone()
     }
-    pub fn start_recording(&self) {
+    pub fn start_recording(&self, tether_agent: &TetherAgent) {
         info!("Tether Record Utility: start recording");
 
         let _input = PlugOptionsBuilder::create_input("all")
             .topic(&self.options.subscribe_topic)
-            .build(&self.tether_agent)
+            .build(&tether_agent)
             .expect("failed to create input plug");
 
         let file_path = match &self.options.file_override_path {
@@ -205,7 +203,7 @@ impl TetherRecordUtil {
                 finished = true;
             } else {
                 let mut did_work = false;
-                while let Some((_plug_name, message)) = self.tether_agent.check_messages() {
+                while let Some((_plug_name, message)) = tether_agent.check_messages() {
                     did_work = true;
 
                     let delta_time = if count == 0 && !self.options.timing_nonzero_start {

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -11,13 +11,9 @@ use std::{
 
 use clap::Args;
 use log::{debug, info, warn};
-use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
+use tether_agent::{PlugOptionsBuilder, TetherAgent};
 
-use crate::{
-    defaults,
-    tether_playback::{SimulationMessage, SimulationRow},
-    Cli,
-};
+use crate::tether_playback::{SimulationMessage, SimulationRow};
 
 #[derive(Args)]
 pub struct RecordOptions {
@@ -57,19 +53,12 @@ pub struct RecordOptions {
     timing_duration: Option<f32>,
 }
 
-pub fn record(cli: &Cli, options: &RecordOptions) {
+pub fn record(options: &RecordOptions, tether_agent: &TetherAgent) {
     info!("Tether Record Utility");
-    let tether_agent = TetherAgentOptionsBuilder::new(defaults::AGENT_ROLE)
-        .host(&cli.tether_host)
-        .port(cli.tether_port)
-        .username(&cli.tether_username)
-        .password(&cli.tether_password)
-        .build()
-        .expect("failed to connect Tether");
 
     let _input = PlugOptionsBuilder::create_input("all")
         .topic(&options.subscribe_topic)
-        .build(&tether_agent)
+        .build(tether_agent)
         .expect("failed to create input plug");
 
     let file_path = match &options.file_override_path {

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -54,6 +54,22 @@ pub struct RecordOptions {
     pub ignore_ctrl_c: bool,
 }
 
+impl Default for RecordOptions {
+    fn default() -> Self {
+        RecordOptions {
+            file_override_path: None,
+            file_base_path: "./".into(),
+            file_base_name: "recording".into(),
+            file_no_timestamp: false,
+            subscribe_topic: "#".into(),
+            timing_nonzero_start: false,
+            timing_delay: None,
+            timing_duration: None,
+            ignore_ctrl_c: false,
+        }
+    }
+}
+
 pub struct TetherRecordUtil {
     stop_request_tx: mpsc::Sender<bool>,
     stop_request_rx: mpsc::Receiver<bool>,

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -1,7 +1,6 @@
 use std::{
     fs::File,
     io::{LineWriter, Write},
-    process::exit,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -122,7 +121,9 @@ pub fn record(options: &RecordOptions, tether_agent: &TetherAgent) {
     })
     .expect("Error setting Ctrl-C handler");
 
-    loop {
+    let mut finished = false;
+
+    while !finished {
         if let Some(delay) = start_delay {
             if let Ok(elapsed) = start_application_time.elapsed() {
                 if elapsed < delay {
@@ -156,7 +157,8 @@ pub fn record(options: &RecordOptions, tether_agent: &TetherAgent) {
             file.flush().unwrap();
             std::thread::sleep(Duration::from_secs(2));
             debug!("Exit now");
-            exit(0);
+            // exit(0);
+            finished = true;
         } else {
             let mut did_work = false;
             while let Some((_plug_name, message)) = tether_agent.check_messages() {

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -62,7 +62,7 @@ pub struct TetherRecordUtil {
 }
 
 impl TetherRecordUtil {
-    pub fn new(options: &RecordOptions, tether_agent: TetherAgent) -> Self {
+    pub fn new(options: RecordOptions, tether_agent: TetherAgent) -> Self {
         info!("Tether Record Utility: initialise");
 
         let (tx, rx) = mpsc::channel();
@@ -70,7 +70,7 @@ impl TetherRecordUtil {
         TetherRecordUtil {
             stop_request_tx: tx,
             stop_request_rx: rx,
-            options: options.clone(),
+            options,
             tether_agent,
         }
     }

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -31,7 +31,7 @@ pub struct RecordOptions {
 
     /// Topic to subscribe; by default we recording everything
     #[arg(long = "topic", default_value_t=String::from("#"))]
-    pub subscribe_topic: String,
+    pub topic: String,
 
     /// Flag to disable zero-ing of the first entry's deltaTime; using this
     /// flag will count time from launch, not first message received
@@ -61,7 +61,7 @@ impl Default for RecordOptions {
             file_base_path: "./".into(),
             file_base_name: "recording".into(),
             file_no_timestamp: false,
-            subscribe_topic: "#".into(),
+            topic: "#".into(),
             timing_nonzero_start: false,
             timing_delay: None,
             timing_duration: None,
@@ -96,7 +96,7 @@ impl TetherRecordUtil {
         info!("Tether Record Utility: start recording");
 
         let _input = PlugOptionsBuilder::create_input("all")
-            .topic(&self.options.subscribe_topic)
+            .topic(&self.options.topic)
             .build(tether_agent)
             .expect("failed to create input plug");
 

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -1,10 +1,7 @@
 use std::{
     fs::File,
     io::{LineWriter, Write},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::mpsc,
     time::{Duration, SystemTime},
 };
 
@@ -14,195 +11,243 @@ use tether_agent::{PlugOptionsBuilder, TetherAgent};
 
 use crate::tether_playback::{SimulationMessage, SimulationRow};
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct RecordOptions {
     /// Specify the full path for the recording file; overrides any other file args
     #[arg(long = "file.overridePath")]
-    file_override_path: Option<String>,
+    pub file_override_path: Option<String>,
 
     /// Base path for recording file
     #[arg(long = "file.path", default_value_t=String::from("./"))]
-    file_base_path: String,
+    pub file_base_path: String,
 
     /// Base name for recording file, excluding timestamp and .json extension
     #[arg(long = "file.name", default_value_t=String::from("recording"))]
-    file_base_name: String,
+    pub file_base_name: String,
 
     /// Flag to disable appending timestamp onto recording file name
     #[arg(long = "file.noTimestamp")]
-    file_no_timestamp: bool,
+    pub file_no_timestamp: bool,
 
     /// Topic to subscribe; by default we recording everything
     #[arg(long = "topic", default_value_t=String::from("#"))]
-    subscribe_topic: String,
+    pub subscribe_topic: String,
 
     /// Flag to disable zero-ing of the first entry's deltaTime; using this
     /// flag will count time from launch, not first message received
     #[arg(long = "timing.nonzeroStart")]
-    timing_nonzero_start: bool,
+    pub timing_nonzero_start: bool,
 
     /// Time (in seconds) to delay writing anything to disk, even if messages are
     /// received
     #[arg(long = "timing.delay")]
-    timing_delay: Option<f32>,
+    pub timing_delay: Option<f32>,
 
     /// Duration (in seconds) to stop recording even if Ctrl+C has not been encountered
     /// yet
     #[arg(long = "timing.duration")]
-    timing_duration: Option<f32>,
+    pub timing_duration: Option<f32>,
+
+    /// Flag to disable registration of Ctrl+C handler - this is usually necessary
+    /// when using the utility programmatically (i.e. not via CLI)
+    #[arg(long = "ignoreCtrlC")]
+    pub ignore_ctrl_c: bool,
 }
 
-pub fn record(options: &RecordOptions, tether_agent: &TetherAgent) {
-    info!("Tether Record Utility");
+pub struct TetherRecordUtil {
+    stop_request_tx: mpsc::Sender<bool>,
+    stop_request_rx: mpsc::Receiver<bool>,
+    options: RecordOptions,
+    tether_agent: TetherAgent,
+}
 
-    let _input = PlugOptionsBuilder::create_input("all")
-        .topic(&options.subscribe_topic)
-        .build(tether_agent)
-        .expect("failed to create input plug");
+impl TetherRecordUtil {
+    pub fn new(options: &RecordOptions, tether_agent: TetherAgent) -> Self {
+        info!("Tether Record Utility: initialise");
 
-    let file_path = match &options.file_override_path {
-        Some(override_path) => String::from(override_path),
-        None => {
-            let timestamp = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or(Duration::from_secs(0))
-                .as_secs();
-            format!(
-                "{}{}-{}.json",
-                options.file_base_path, options.file_base_name, timestamp
-            )
+        let (tx, rx) = mpsc::channel();
+
+        TetherRecordUtil {
+            stop_request_tx: tx,
+            stop_request_rx: rx,
+            options: options.clone(),
+            tether_agent,
         }
-    };
+    }
 
-    info!("Writing recorded data to {} ...", &file_path);
+    pub fn get_stop_tx(&self) -> mpsc::Sender<bool> {
+        self.stop_request_tx.clone()
+    }
+    pub fn start_recording(&self) {
+        info!("Tether Record Utility: start recording");
 
-    let file = File::create(&file_path).expect("failed to create file");
-    let mut file = LineWriter::new(file);
+        let _input = PlugOptionsBuilder::create_input("all")
+            .topic(&self.options.subscribe_topic)
+            .build(&self.tether_agent)
+            .expect("failed to create input plug");
 
-    let buf = b"[";
-    file.write_all(buf).expect("failed to write first line");
-
-    let max_duration = match options.timing_duration {
-        Some(dur) => {
-            warn!(
-                "Max duration was set to {}s; Ctr+C to stop before that point ...",
-                dur
-            );
-            Some(Duration::from_secs_f32(dur))
-        }
-        None => {
-            warn!("No duration provided; recording runs until you press Ctrl+C ...");
-            None
-        }
-    };
-
-    let start_delay = match options.timing_delay {
-        Some(dur) => {
-            warn!("Recording will only start after {}s", dur);
-            Some(Duration::from_secs_f32(dur))
-        }
-        None => {
-            debug!("No start delay set");
-            None
-        }
-    };
-
-    let start_application_time = SystemTime::now();
-    let mut first_message_time = SystemTime::now();
-    let mut previous_message_time = SystemTime::now();
-
-    let mut count: i128 = 0;
-    let should_stop = Arc::new(AtomicBool::new(false));
-    let should_stop_clone = Arc::clone(&should_stop);
-
-    ctrlc::set_handler(move || {
-        should_stop_clone.store(true, Ordering::Relaxed);
-        warn!("received Ctrl+C!");
-    })
-    .expect("Error setting Ctrl-C handler");
-
-    let mut finished = false;
-
-    while !finished {
-        if let Some(delay) = start_delay {
-            if let Ok(elapsed) = start_application_time.elapsed() {
-                if elapsed < delay {
-                    continue;
-                }
+        let file_path = match &self.options.file_override_path {
+            Some(override_path) => String::from(override_path),
+            None => {
+                let timestamp = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap_or(Duration::from_secs(0))
+                    .as_secs();
+                format!(
+                    "{}{}-{}.json",
+                    self.options.file_base_path, self.options.file_base_name, timestamp
+                )
             }
+        };
+
+        info!("Writing recorded data to {} ...", &file_path);
+
+        let file = File::create(&file_path).expect("failed to create file");
+        let mut file = LineWriter::new(file);
+
+        let buf = b"[";
+        file.write_all(buf).expect("failed to write first line");
+
+        let max_duration = match self.options.timing_duration {
+            Some(dur) => {
+                warn!(
+                    "Max duration was set to {}s; Ctr+C to stop before that point ...",
+                    dur
+                );
+                Some(Duration::from_secs_f32(dur))
+            }
+            None => {
+                warn!("No duration provided; recording runs until you press Ctrl+C ...");
+                None
+            }
+        };
+
+        let start_delay = match self.options.timing_delay {
+            Some(dur) => {
+                warn!("Recording will only start after {}s", dur);
+                Some(Duration::from_secs_f32(dur))
+            }
+            None => {
+                debug!("No start delay set");
+                None
+            }
+        };
+
+        let start_application_time = SystemTime::now();
+        let mut first_message_time = SystemTime::now();
+        let mut previous_message_time = SystemTime::now();
+
+        let mut count: i128 = 0;
+
+        let stop_from_key = self.stop_request_tx.clone();
+        let stop_from_timer = self.stop_request_tx.clone();
+        // let stop_tx_clone = stop_tx.clone();
+
+        // let should_stop = Arc::new(AtomicBool::new(false));
+        // let should_stop_clone = Arc::clone(&should_stop);
+
+        if !self.options.ignore_ctrl_c {
+            ctrlc::set_handler(move || {
+                // should_stop_clone.store(true, Ordering::Relaxed);
+                stop_from_key
+                    .send(true)
+                    .expect("failed to send stop from key");
+                warn!("received Ctrl+C!");
+            })
+            .expect("Error setting Ctrl-C handler");
+        } else {
+            warn!(
+                "No Ctrl+C handler set; you may need to kill this process manually, PID: {}",
+                std::process::id()
+            );
         }
 
-        if let Some(dur) = max_duration {
-            if let Ok(elapsed) = first_message_time.elapsed() {
-                if elapsed > dur {
-                    if count == 0 && !options.timing_nonzero_start {
-                        debug!("Ignore duration; nothing received yet")
-                    } else {
-                        warn!(
-                            "Exceeded the max duration specified ({}s); will stop now...",
-                            dur.as_secs_f32()
-                        );
-                        should_stop.store(true, Ordering::Relaxed);
+        let mut finished = false;
+
+        while !finished {
+            if let Some(delay) = start_delay {
+                if let Ok(elapsed) = start_application_time.elapsed() {
+                    if elapsed < delay {
+                        continue;
                     }
                 }
             }
-        }
-        if should_stop.load(Ordering::Relaxed) {
-            info!(
-                "Stopping after {} entries written to disk; end file cleanly, wait then exit",
-                count
-            );
-            file.write_all(b"\n]")
-                .expect("failed to close JSON file properly");
-            file.flush().unwrap();
-            std::thread::sleep(Duration::from_secs(2));
-            debug!("Exit now");
-            // exit(0);
-            finished = true;
-        } else {
-            let mut did_work = false;
-            while let Some((_plug_name, message)) = tether_agent.check_messages() {
-                did_work = true;
 
-                let delta_time = if count == 0 && !options.timing_nonzero_start {
-                    first_message_time = SystemTime::now();
-                    Duration::ZERO
-                } else {
-                    previous_message_time.elapsed().unwrap_or_default()
-                };
-                previous_message_time = SystemTime::now();
-
-                debug!("Received message on topic \"{}\"", message.topic());
-                let bytes = message.payload();
-                let row = SimulationRow {
-                    topic: message.topic().into(),
-                    message: SimulationMessage {
-                        r#type: "Buffer".into(),
-                        data: bytes.to_vec(),
-                    },
-                    delta_time: delta_time.as_millis() as u64,
-                };
-
-                if count == 0 {
-                    file.write_all(b"\n").unwrap(); // line break only
-                    info!("First message written to disk");
-                } else {
-                    file.write_all(b",\n").unwrap(); // comma, line break
+            if let Some(dur) = max_duration {
+                if let Ok(elapsed) = first_message_time.elapsed() {
+                    if elapsed > dur {
+                        if count == 0 && !self.options.timing_nonzero_start {
+                            debug!("Ignore duration; nothing received yet")
+                        } else {
+                            warn!(
+                                "Exceeded the max duration specified ({}s); will stop now...",
+                                dur.as_secs_f32()
+                            );
+                            // should_stop.store(true, Ordering::Relaxed);
+                            stop_from_timer
+                                .send(true)
+                                .expect("failed to send stop from timer");
+                        }
+                    }
                 }
-
-                let json =
-                    serde_json::to_string(&row).expect("failed to convert to stringified JSON");
-                file.write_all(json.as_bytes())
-                    .expect("failed to write new entry");
-
-                file.flush().unwrap();
-
-                count += 1;
-
-                debug!("Wrote {} rows", count);
             }
-            if !did_work {
-                std::thread::sleep(std::time::Duration::from_micros(100)); //0.1 ms
+            if let Ok(_should_stop) = self.stop_request_rx.try_recv() {
+                info!(
+                    "Stopping after {} entries written to disk; end file cleanly, wait then exit",
+                    count
+                );
+                file.write_all(b"\n]")
+                    .expect("failed to close JSON file properly");
+                file.flush().unwrap();
+                std::thread::sleep(Duration::from_secs(2));
+                debug!("Exit now");
+                // exit(0);
+                finished = true;
+            } else {
+                let mut did_work = false;
+                while let Some((_plug_name, message)) = self.tether_agent.check_messages() {
+                    did_work = true;
+
+                    let delta_time = if count == 0 && !self.options.timing_nonzero_start {
+                        first_message_time = SystemTime::now();
+                        Duration::ZERO
+                    } else {
+                        previous_message_time.elapsed().unwrap_or_default()
+                    };
+                    previous_message_time = SystemTime::now();
+
+                    debug!("Received message on topic \"{}\"", message.topic());
+                    let bytes = message.payload();
+                    let row = SimulationRow {
+                        topic: message.topic().into(),
+                        message: SimulationMessage {
+                            r#type: "Buffer".into(),
+                            data: bytes.to_vec(),
+                        },
+                        delta_time: delta_time.as_millis() as u64,
+                    };
+
+                    if count == 0 {
+                        file.write_all(b"\n").unwrap(); // line break only
+                        info!("First message written to disk");
+                    } else {
+                        file.write_all(b",\n").unwrap(); // comma, line break
+                    }
+
+                    let json =
+                        serde_json::to_string(&row).expect("failed to convert to stringified JSON");
+                    file.write_all(json.as_bytes())
+                        .expect("failed to write new entry");
+
+                    file.flush().unwrap();
+
+                    count += 1;
+
+                    debug!("Wrote {} rows", count);
+                }
+                if !did_work {
+                    std::thread::sleep(std::time::Duration::from_micros(100)); //0.1 ms
+                }
             }
         }
     }

--- a/utilities/tether-utils/src/tether_send.rs
+++ b/utilities/tether-utils/src/tether_send.rs
@@ -66,7 +66,10 @@ pub fn send(options: &SendOptions, tether_agent: &TetherAgent) -> anyhow::Result
         };
         info!("Sending dummy data {:?}", payload);
         return match tether_agent.encode_and_publish(&output, &payload) {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                info!("Sent dummy data message OK");
+                Ok(())
+            }
             Err(e) => Err(e),
         };
     }

--- a/utilities/tether-utils/src/tether_send.rs
+++ b/utilities/tether-utils/src/tether_send.rs
@@ -105,7 +105,7 @@ pub fn send(options: &SendOptions, tether_agent: &TetherAgent) -> anyhow::Result
                 }
                 Err(e) => {
                     error!("Failed to send empty message: {}", e);
-                    Err(e.into())
+                    Err(e)
                 }
             }
         }

--- a/utilities/tether-utils/src/tether_send.rs
+++ b/utilities/tether-utils/src/tether_send.rs
@@ -79,7 +79,7 @@ pub fn send(options: &SendOptions, tether_agent: &TetherAgent) -> anyhow::Result
         info!("Sending dummy data {:?}", payload);
         match tether_agent.encode_and_publish(&output, &payload) {
             Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e),
         }
     }
 }

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -10,14 +10,12 @@ use tether_agent::{
 #[derive(Args, Clone)]
 pub struct TopicOptions {
     #[arg(long = "topic", default_value_t=String::from("#"))]
-    pub subscribe_topic: String,
+    pub topic: String,
 }
 
 impl Default for TopicOptions {
     fn default() -> Self {
-        TopicOptions {
-            subscribe_topic: "#".into(),
-        }
+        TopicOptions { topic: "#".into() }
     }
 }
 
@@ -50,7 +48,7 @@ impl Insights {
             panic!("Insights utility needs already-connected Tether Agent");
         }
         let _input_plug = PlugOptionsBuilder::create_input("monitor")
-            .topic(&options.subscribe_topic)
+            .topic(&options.topic)
             .build(tether_agent)
             .expect("failed to connect Tether");
 

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -200,6 +200,9 @@ impl Insights {
     pub fn plugs(&self) -> &[String] {
         &self.plugs
     }
+    pub fn trees(&self) -> &[AgentTree] {
+        &self.trees
+    }
 
     pub fn message_count(&self) -> u128 {
         self.message_count

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -51,22 +51,26 @@ impl AgentTree {
         let ids = topics_this_agent
             .clone()
             .fold(Vec::new(), |mut acc, topic| {
-                // match parse_agent_id(&x) {
-                //     Some(id) => acc.push(String::from(id)),
-                //     None => {}
-                // };
-                // acc
-                acc.push(String::from(parse_agent_id(&topic).unwrap_or("unknown")));
+                match parse_agent_id(&topic) {
+                    Some(id) => {
+                        if !acc.iter().any(|x| x == id) {
+                            acc.push(String::from(id))
+                        }
+                    }
+                    None => {}
+                }
                 acc
             });
 
-        let output_plugs = topics_this_agent.clone().fold(Vec::new(), |mut acc, x| {
-            match parse_plug_name(&x) {
-                Some(p) => acc.push(String::from(p)),
-                None => {}
-            }
-            acc
-        });
+        let output_plugs = topics_this_agent
+            .clone()
+            .fold(Vec::new(), |mut acc, topic| {
+                match parse_plug_name(&topic) {
+                    Some(p) => acc.push(String::from(p)),
+                    None => {}
+                }
+                acc
+            });
 
         AgentTree {
             role: role.into(),
@@ -85,11 +89,11 @@ impl fmt::Display for AgentTree {
         } = self;
         let ids_list = ids
             .iter()
-            .fold(String::from(""), |acc, x| format!("{}\n-{}", acc, x));
-        let output_plugs_list = output_plugs
-            .iter()
-            .fold(String::from(""), |acc, x| format!("{}\n-{}", acc, x));
-        write!(f, "{}\n    {}\n    {}", role, ids_list, output_plugs_list)
+            .fold(String::from(""), |acc, x| format!("{}\n    - {}", acc, x));
+        let output_plugs_list = output_plugs.iter().fold(String::from(""), |acc, x| {
+            format!("{}\n        - {}", acc, x)
+        });
+        write!(f, "\n{}\n {}\n {}\n", role, ids_list, output_plugs_list)
     }
 }
 
@@ -110,7 +114,7 @@ impl fmt::Display for Insights {
 
         write!(
             f,
-            "{}{}{}{}{}\n{}",
+            "{}{}{}{}{}{}",
             topics, roles, ids, plugs, message_count, trees_formatted
         )
     }

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -52,13 +52,10 @@ impl AgentTree {
         let ids = topics_this_agent
             .clone()
             .fold(Vec::new(), |mut acc, topic| {
-                match parse_agent_id(&topic) {
-                    Some(id) => {
-                        if !acc.iter().any(|x| x == id) {
-                            acc.push(String::from(id))
-                        }
+                if let Some(id) = parse_agent_id(&topic) {
+                    if !acc.iter().any(|x| x == id) {
+                        acc.push(String::from(id))
                     }
-                    None => {}
                 }
                 acc
             });
@@ -66,9 +63,8 @@ impl AgentTree {
         let output_plugs = topics_this_agent
             .clone()
             .fold(Vec::new(), |mut acc, topic| {
-                match parse_plug_name(&topic) {
-                    Some(p) => acc.push(String::from(p)),
-                    None => {}
+                if let Some(p) = parse_plug_name(&topic) {
+                    acc.push(String::from(p));
                 }
                 acc
             });

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -2,10 +2,8 @@ use clap::Args;
 use log::info;
 use tether_agent::{
     mqtt::Message, parse_agent_id, parse_agent_role, parse_plug_name, PlugOptionsBuilder,
-    TetherAgentOptionsBuilder,
+    TetherAgent,
 };
-
-use crate::{defaults, Cli};
 
 #[derive(Args)]
 pub struct TopicOptions {
@@ -73,20 +71,12 @@ fn add_if_unique(item: &str, list: &mut Vec<String>) -> bool {
     }
 }
 
-pub fn topics(cli: &Cli, options: &TopicOptions) {
+pub fn topics(options: &TopicOptions, tether_agent: &TetherAgent) {
     info!("Tether Topics Parsing Utility");
-
-    let tether_agent = TetherAgentOptionsBuilder::new(defaults::AGENT_ROLE)
-        .host(&cli.tether_host)
-        .port(cli.tether_port)
-        .username(&cli.tether_username)
-        .password(&cli.tether_password)
-        .build()
-        .expect("failed to connect Tether");
 
     let _input = PlugOptionsBuilder::create_input("all")
         .topic(&options.subscribe_topic)
-        .build(&tether_agent);
+        .build(tether_agent);
 
     let mut insights = Insights::new();
 

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -68,7 +68,7 @@ impl Insights {
     ) -> bool {
         match input_plug_subscribed {
             PlugDefinition::InputPlugDefinition(_) => {
-                debug!("Input Plugs are ok; make sure you have subscribed")
+                // debug!("Input Plugs are ok; make sure you have subscribed")
             }
             _ => panic!("You should have created an Input Plug"),
         };

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -13,11 +13,11 @@ pub struct TopicOptions {
 
 #[derive(Debug)]
 pub struct Insights {
-    pub topics: Vec<String>,
-    pub roles: Vec<String>,
-    pub ids: Vec<String>,
-    pub plugs: Vec<String>,
-    // message_count: u64,
+    topics: Vec<String>,
+    roles: Vec<String>,
+    ids: Vec<String>,
+    plugs: Vec<String>,
+    message_count: u128,
 }
 
 impl Insights {
@@ -27,12 +27,12 @@ impl Insights {
             roles: Vec::new(),
             ids: Vec::new(),
             plugs: Vec::new(),
-            // message_count: 0,
+            message_count: 0,
         }
     }
 
     pub fn update(&mut self, message: &Message) -> bool {
-        // self.message_count += 1;
+        self.message_count += 1;
         let mut did_change = false;
 
         // Collect some stats...
@@ -84,6 +84,24 @@ impl Insights {
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
         false
+    }
+
+    pub fn topics(&self) -> &[String] {
+        &self.topics
+    }
+
+    pub fn roles(&self) -> &[String] {
+        &self.roles
+    }
+    pub fn ids(&self) -> &[String] {
+        &self.ids
+    }
+    pub fn plugs(&self) -> &[String] {
+        &self.plugs
+    }
+
+    pub fn message_count(&self) -> u128 {
+        self.message_count
     }
 }
 

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -27,6 +27,7 @@ pub struct Insights {
     roles: Vec<String>,
     ids: Vec<String>,
     plugs: Vec<String>,
+    trees: Vec<AgentTree>,
     message_count: u128,
     message_log: CircularBuffer<MONITOR_LOG_LENGTH, MessageLogEntry>,
 }
@@ -39,7 +40,7 @@ pub struct AgentTree {
 }
 
 impl AgentTree {
-    fn new(role: &str, topics: &[String]) -> AgentTree {
+    pub fn new(role: &str, topics: &[String]) -> AgentTree {
         let topics_this_agent = topics.iter().filter_map(|topic| {
             if topic.contains(role) {
                 Some(String::from(topic))
@@ -105,12 +106,7 @@ impl fmt::Display for Insights {
         let plugs = format!("x{} Plugs: {:?} \n", self.plugs().len(), self.plugs());
         let message_count = format!("x{} Messages total \n", self.message_count());
 
-        let trees = self
-            .roles()
-            .iter()
-            .map(|role| AgentTree::new(role.as_str(), self.topics()))
-            .collect::<Vec<AgentTree>>();
-        let trees_formatted = trees.iter().map(|x| x.to_string()).collect::<String>();
+        let trees_formatted = self.trees.iter().map(|x| x.to_string()).collect::<String>();
 
         write!(
             f,
@@ -135,6 +131,7 @@ impl Insights {
             roles: Vec::new(),
             ids: Vec::new(),
             plugs: Vec::new(),
+            trees: Vec::new(),
             message_log: CircularBuffer::new(),
             message_count: 0,
         }
@@ -177,6 +174,14 @@ impl Insights {
             &mut self.plugs,
         ) {
             did_change = true;
+        }
+
+        if did_change {
+            self.trees = self
+                .roles()
+                .iter()
+                .map(|role| AgentTree::new(role.as_str(), self.topics()))
+                .collect::<Vec<AgentTree>>();
         }
 
         did_change

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -34,9 +34,9 @@ pub struct Insights {
 
 /// Role, IDs, OutputPlugs
 pub struct AgentTree {
-    role: String,
-    ids: Vec<String>,
-    output_plugs: Vec<String>,
+    pub role: String,
+    pub ids: Vec<String>,
+    pub output_plugs: Vec<String>,
 }
 
 impl AgentTree {

--- a/utilities/tether-utils/src/tether_topics.rs
+++ b/utilities/tether-utils/src/tether_topics.rs
@@ -8,7 +8,7 @@ use tether_agent::{
 #[derive(Args)]
 pub struct TopicOptions {
     #[arg(long = "topic", default_value_t=String::from("#"))]
-    subscribe_topic: String,
+    pub subscribe_topic: String,
 }
 
 #[derive(Debug)]
@@ -71,7 +71,7 @@ fn add_if_unique(item: &str, list: &mut Vec<String>) -> bool {
     }
 }
 
-pub fn topics(options: &TopicOptions, tether_agent: &TetherAgent) {
+pub fn topics(options: &TopicOptions, tether_agent: &TetherAgent, on_update: fn(result: String)) {
     info!("Tether Topics Parsing Utility");
 
     let _input = PlugOptionsBuilder::create_input("all")
@@ -85,7 +85,8 @@ pub fn topics(options: &TopicOptions, tether_agent: &TetherAgent) {
         while let Some((plug_name, message)) = tether_agent.check_messages() {
             did_work = true;
             if insights.update(&plug_name, &message) {
-                info!("{:#?}", insights);
+                let result = format!("{:#?}", insights);
+                on_update(result);
             }
         }
         if !did_work {


### PR DESCRIPTION
This retains all the previous functionality of the `tether` command, but also allows the utility functions such as record, playback, etc. to be used programmatically, i.e. via an API rather than only a command-line interface.

The crate thus becomes a library in addition to retaining the `tether` binary as before - but even the binary uses the same library modules and functions.

The `examples/api.rs` demonstrates how the API would be used; this has also been implemented and tested in the latest version of Tether egui.