### PR TITLE
Feature/three part topics for Rust Base Agent

### DIFF
--- a/base_agent/rs/Cargo.lock
+++ b/base_agent/rs/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/base_agent/rs/Cargo.toml
+++ b/base_agent/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-agent"
 description = "Standardised use of MQTT and MessagePack for inter-process communication"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -4,11 +4,11 @@ use tether_agent::{
 
 fn main() {
     let tether_agent = TetherAgentOptionsBuilder::new("example")
-        .id_optional(None)
-        .host("localhost")
+        .id(None)
+        .host(Some("localhost".into()))
         .port(1883)
-        .username("tether")
-        .password("sp_ceB0ss!")
+        .username(Some("tether".into()))
+        .password(Some("sp_ceB0ss!".into()))
         .build()
         .expect("failed to create Tether Agent");
 

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -11,11 +11,17 @@ fn main() {
         .expect("failed to create Tether Agent");
 
     let output_plug = PlugOptionsBuilder::create_output("anOutput")
+        .role(Some("pretendingToBeSomethingElse"))
         .qos(2)
         .retain(true)
         .build(&tether_agent);
-    let input_plug = PlugOptionsBuilder::create_input("everything")
+    let input_wildcard_plug = PlugOptionsBuilder::create_input("everything")
         .topic("#")
+        .build(&tether_agent);
+
+    let input_customid_plug = PlugOptionsBuilder::create_input("someData")
+        .role(None) // i.e., just use default
+        .id(Some("specificIDonly"))
         .build(&tether_agent);
 
     println!("Agent looks like this: {:?}", tether_agent.description());
@@ -24,5 +30,10 @@ fn main() {
     assert_eq!(id, "any"); // because we set None
 
     println!("output plug: {:?}", output_plug);
-    println!("input plug: {:?}", input_plug);
+    assert_eq!(
+        output_plug.unwrap().topic(),
+        "pretendingToBeSomethingElse/any/anOutput"
+    );
+    println!("wildcard input plug: {:?}", input_wildcard_plug);
+    println!("speific ID input plug: {:?}", input_customid_plug);
 }

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -1,4 +1,6 @@
-use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
+use tether_agent::{
+    PlugDefinition, PlugDefinitionCommon, PlugOptionsBuilder, TetherAgentOptionsBuilder,
+};
 
 fn main() {
     let tether_agent = TetherAgentOptionsBuilder::new("example")
@@ -29,11 +31,11 @@ fn main() {
     assert_eq!(role, "example");
     assert_eq!(id, "any"); // because we set None
 
-    println!("output plug: {:?}", output_plug);
-    assert_eq!(
-        output_plug.unwrap().topic(),
-        "pretendingToBeSomethingElse/any/anOutput"
-    );
+    if let PlugDefinition::OutputPlug(p) = output_plug.unwrap() {
+        println!("output plug: {:?}", p);
+        assert_eq!(p.topic(), "pretendingToBeSomethingElse/any/anOutput");
+    }
+
     println!("wildcard input plug: {:?}", input_wildcard_plug);
     println!("speific ID input plug: {:?}", input_customid_plug);
 }

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -13,17 +13,17 @@ fn main() {
         .expect("failed to create Tether Agent");
 
     let output_plug = PlugOptionsBuilder::create_output("anOutput")
-        .role(Some("pretendingToBeSomethingElse"))
+        .role(Some("pretendingToBeSomethingElse".into()))
         .qos(2)
         .retain(true)
         .build(&tether_agent);
     let input_wildcard_plug = PlugOptionsBuilder::create_input("everything")
-        .topic("#")
+        .topic(Some("#".into()))
         .build(&tether_agent);
 
     let input_customid_plug = PlugOptionsBuilder::create_input("someData")
         .role(None) // i.e., just use default
-        .id(Some("specificIDonly"))
+        .id(Some("specificIDonly".into()))
         .build(&tether_agent);
 
     println!("Agent looks like this: {:?}", tether_agent.description());

--- a/base_agent/rs/examples/error_handling.rs
+++ b/base_agent/rs/examples/error_handling.rs
@@ -65,7 +65,8 @@ fn main() {
         .publish(&output, Some(bad_payload))
         .expect("This will produce an error when DECODING, but not checked by library");
 
-    let bad_topic_input = PlugOptionsBuilder::create_input("something").topic("*/#/house+");
+    let bad_topic_input =
+        PlugOptionsBuilder::create_input("something").topic(Some("*/#/house+".into()));
     match bad_topic_input.build(&working_tether_agent) {
         Ok(_) => panic!("Weird topic: This shouldn't work!"),
         Err(e) => warn!("Got a subscribe error (bad topic) as expected: {e:?}"),

--- a/base_agent/rs/examples/error_handling.rs
+++ b/base_agent/rs/examples/error_handling.rs
@@ -16,9 +16,9 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let bad_tether_agent = TetherAgentOptionsBuilder::new("tester")
-        .host("tether-io.dev")
-        .username("bla")
-        .password("bla")
+        .host(Some("tether-io.dev".into()))
+        .username(Some("bla".into()))
+        .password(Some("bla".into()))
         .build();
     match bad_tether_agent {
         Ok(_agent) => {
@@ -28,7 +28,7 @@ fn main() {
     }
 
     let disconnected = TetherAgentOptionsBuilder::new("tester")
-        .host("tether-io.dev")
+        .host(Some("tether-io.dev".into()))
         .auto_connect(false)
         .build()
         .expect("this ought initialise but not conect");

--- a/base_agent/rs/examples/publish.rs
+++ b/base_agent/rs/examples/publish.rs
@@ -32,7 +32,7 @@ fn main() {
         .build(&agent)
         .expect("failed to create output");
     let custom_output = PlugOptionsBuilder::create_output("two")
-        .topic("custom/custom/two")
+        .topic(Some("custom/custom/two".into()))
         .build(&agent)
         .expect("failed to create output");
 

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -23,7 +23,7 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
-        .id("example")
+        .id(Some("example".into()))
         .build()
         .expect("failed to init Tether agent");
 

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -44,6 +44,8 @@ fn main() {
         .build(&tether_agent)
         .expect("failed to create input");
 
+    let plug_names = vec![input_one. ]
+
     info!("Checking messages every 1s, 10x...");
 
     for i in 1..10 {
@@ -54,42 +56,49 @@ fn main() {
                 message.topic(),
                 topic_parts
             );
-            // if &plug_name == input_one.name() {
-            //     info!(
-            //         "******** INPUT ONE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
-            //         input_one.name(),
-            //         message.topic(),
-            //         message.payload().len()
-            //     );
+            let plug_name = topic_parts.plug_name();
+
+            // match plug_name {
+            //     input_one.name() => {}
+            //     &_ => {}
             // }
-            // if &plug_name == input_two.name() {
-            //     info!(
-            //         "******** INPUT TWO:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
-            //         input_two.name(),
-            //         message.topic(),
-            //         message.payload().len()
-            //     );
-            //     // Notice how you must give the from_slice function a type so it knows what to expect
-            //     let decoded = from_slice::<CustomMessage>(&message.payload());
-            //     match decoded {
-            //         Ok(d) => {
-            //             info!("Yes, we decoded the MessagePack payload as: {:?}", d);
-            //             let CustomMessage { name, id } = d;
-            //             debug!("Name is {} and ID is {}", name, id);
-            //         }
-            //         Err(e) => {
-            //             warn!("Failed to decode the payload: {}", e)
-            //         }
-            //     };
-            // }
-            // if &plug_name == input_empty.name() {
-            //     info!(
-            //         "******** EMPTY MESSAGE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
-            //         input_empty.name(),
-            //         message.topic(),
-            //         message.payload().len()
-            //     );
-            // }
+
+            if plug_name == input_one.name() {
+                info!(
+                    "******** INPUT ONE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
+                    input_one.name(),
+                    message.topic(),
+                    message.payload().len()
+                );
+            }
+            if plug_name == input_two.name() {
+                info!(
+                    "******** INPUT TWO:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
+                    input_two.name(),
+                    message.topic(),
+                    message.payload().len()
+                );
+                // Notice how you must give the from_slice function a type so it knows what to expect
+                let decoded = from_slice::<CustomMessage>(&message.payload());
+                match decoded {
+                    Ok(d) => {
+                        info!("Yes, we decoded the MessagePack payload as: {:?}", d);
+                        let CustomMessage { name, id } = d;
+                        debug!("Name is {} and ID is {}", name, id);
+                    }
+                    Err(e) => {
+                        warn!("Failed to decode the payload: {}", e)
+                    }
+                };
+            }
+            if plug_name == input_empty.name() {
+                info!(
+                    "******** EMPTY MESSAGE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
+                    input_empty.name(),
+                    message.topic(),
+                    message.payload().len()
+                );
+            }
         }
         thread::sleep(Duration::from_millis(1000))
     }

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -39,52 +39,57 @@ fn main() {
         .build(&tether_agent)
         .expect("failed to create input");
 
+    let input_everything = PlugOptionsBuilder::create_input("everything")
+        .topic("#")
+        .build(&tether_agent)
+        .expect("failed to create input");
+
     info!("Checking messages every 1s, 10x...");
 
     for i in 1..10 {
         info!("#{i}: Checking for messages...");
-        while let Some((plug_name, message)) = tether_agent.check_messages() {
+        while let Some((topic_parts, message)) = tether_agent.check_messages() {
             debug!(
-                "Received a message topic {} => plug name {}",
+                "Received a message topic {} => topic parts {:?}",
                 message.topic(),
-                plug_name
+                topic_parts
             );
-            if &plug_name == input_one.name() {
-                info!(
-                    "******** INPUT ONE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
-                    input_one.name(),
-                    message.topic(),
-                    message.payload().len()
-                );
-            }
-            if &plug_name == input_two.name() {
-                info!(
-                    "******** INPUT TWO:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
-                    input_two.name(),
-                    message.topic(),
-                    message.payload().len()
-                );
-                // Notice how you must give the from_slice function a type so it knows what to expect
-                let decoded = from_slice::<CustomMessage>(&message.payload());
-                match decoded {
-                    Ok(d) => {
-                        info!("Yes, we decoded the MessagePack payload as: {:?}", d);
-                        let CustomMessage { name, id } = d;
-                        debug!("Name is {} and ID is {}", name, id);
-                    }
-                    Err(e) => {
-                        warn!("Failed to decode the payload: {}", e)
-                    }
-                };
-            }
-            if &plug_name == input_empty.name() {
-                info!(
-                    "******** EMPTY MESSAGE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
-                    input_empty.name(),
-                    message.topic(),
-                    message.payload().len()
-                );
-            }
+            // if &plug_name == input_one.name() {
+            //     info!(
+            //         "******** INPUT ONE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
+            //         input_one.name(),
+            //         message.topic(),
+            //         message.payload().len()
+            //     );
+            // }
+            // if &plug_name == input_two.name() {
+            //     info!(
+            //         "******** INPUT TWO:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
+            //         input_two.name(),
+            //         message.topic(),
+            //         message.payload().len()
+            //     );
+            //     // Notice how you must give the from_slice function a type so it knows what to expect
+            //     let decoded = from_slice::<CustomMessage>(&message.payload());
+            //     match decoded {
+            //         Ok(d) => {
+            //             info!("Yes, we decoded the MessagePack payload as: {:?}", d);
+            //             let CustomMessage { name, id } = d;
+            //             debug!("Name is {} and ID is {}", name, id);
+            //         }
+            //         Err(e) => {
+            //             warn!("Failed to decode the payload: {}", e)
+            //         }
+            //     };
+            // }
+            // if &plug_name == input_empty.name() {
+            //     info!(
+            //         "******** EMPTY MESSAGE:\n Received a message from plug named \"{}\" on topic {} with length {} bytes",
+            //         input_empty.name(),
+            //         message.topic(),
+            //         message.payload().len()
+            //     );
+            // }
         }
         thread::sleep(Duration::from_millis(1000))
     }

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -4,7 +4,7 @@ use env_logger::{Builder, Env};
 use log::{debug, info, warn};
 use rmp_serde::from_slice;
 use serde::Deserialize;
-use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder, TetherOrCustomTopic};
+use tether_agent::{PlugOptionsBuilder, TetherAgentOptionsBuilder};
 
 #[derive(Deserialize, Debug)]
 struct CustomMessage {
@@ -32,7 +32,7 @@ fn main() {
         .expect("failed to create input");
     debug!("input one {} = {}", input_one.name(), input_one.topic());
     let input_two = PlugOptionsBuilder::create_input("two")
-        .role(Some("specific"))
+        .role(Some("specific".into()))
         .build(&tether_agent)
         .expect("failed to create input");
     debug!("input two {} = {}", input_two.name(), input_two.topic());
@@ -41,7 +41,7 @@ fn main() {
         .expect("failed to create input");
 
     let input_everything = PlugOptionsBuilder::create_input("everything")
-        .topic("#")
+        .topic(Some("#".into()))
         .build(&tether_agent)
         .expect("failed to create input");
     debug!(

--- a/base_agent/rs/examples/subscribe_publish_threaded.rs
+++ b/base_agent/rs/examples/subscribe_publish_threaded.rs
@@ -77,7 +77,7 @@ fn main() {
                 Ok(a) => {
                     if let Some((topic, _message)) = a.check_messages() {
                         count_messages_received += 1;
-                        println!("<<<<<<<< CHECKING LOOP: Received a message on topic {topic}; Now has {count_messages_received} messages");
+                        println!("<<<<<<<< CHECKING LOOP: Received a message on topic {topic:?}; Now has {count_messages_received} messages");
                     }
                 }
                 Err(e) => {

--- a/base_agent/rs/examples/subscribe_publish_threaded.rs
+++ b/base_agent/rs/examples/subscribe_publish_threaded.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let tether_agent = Arc::new(Mutex::new(
         TetherAgentOptionsBuilder::new("RustDemoAgent")
-            .id("example")
+            .id(Some("example".into()))
             .build()
             .expect("failed to init/connect"),
     ));

--- a/base_agent/rs/examples/subscribe_threaded.rs
+++ b/base_agent/rs/examples/subscribe_threaded.rs
@@ -27,7 +27,7 @@ fn main() {
 
     let tether_agent = Arc::new(Mutex::new(
         TetherAgentOptionsBuilder::new("RustDemoAgent")
-            .id("example")
+            .id(Some("example".into()))
             .build()
             .expect("failed to init/connect"),
     ));

--- a/base_agent/rs/examples/subscribe_threaded.rs
+++ b/base_agent/rs/examples/subscribe_threaded.rs
@@ -34,7 +34,7 @@ fn main() {
 
     match tether_agent.lock() {
         Ok(a) => {
-            let _input_plug = PlugOptionsBuilder::create_output("one").build(&a);
+            let _input_plug = PlugOptionsBuilder::create_input("one").build(&a);
         }
         Err(e) => {
             panic!("Failed to acquire lock for Tether Agent setup: {}", e);
@@ -45,7 +45,7 @@ fn main() {
 
     let receiver_agent = Arc::clone(&tether_agent);
     thread::spawn(move || {
-        println!("Checking messages every 1s, 10x...");
+        println!("Checking messages every 1s, until 10 messages received...");
 
         let mut message_count = 0;
         // let mut i = 0;

--- a/base_agent/rs/examples/subscribe_threaded.rs
+++ b/base_agent/rs/examples/subscribe_threaded.rs
@@ -57,7 +57,7 @@ fn main() {
                 Ok(a) => {
                     if let Some((topic, _message)) = a.check_messages() {
                         message_count += 1;
-                        println!("<<<<<<<< CHECKING LOOP: Received a message on topic {topic}",);
+                        println!("<<<<<<<< CHECKING LOOP: Received a message on topic {topic:?}",);
                         tx.send(format!("received message #{message_count}"))
                             .expect("failed to send message via channel");
                     }

--- a/base_agent/rs/examples/username_password.rs
+++ b/base_agent/rs/examples/username_password.rs
@@ -20,9 +20,9 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
-        .host("10.112.10.10")
-        .username("connected.space")
-        .password("connected.space")
+        .host(Some("10.112.10.10".into()))
+        .username(Some("connected.space".into()))
+        .password(Some("connected.space".into()))
         .build()
         .expect("Failed to initialise and connect");
     let (role, id, _) = tether_agent.description();

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -212,9 +212,12 @@ impl TetherAgent {
             if let Ok(t) = ThreePartTopic::try_from(message.topic()) {
                 Some((t, message))
             } else {
-                error!("Could not pass Three Part Topic from \"{}\"", message.topic());
+                error!(
+                    "Could not pass Three Part Topic from \"{}\"",
+                    message.topic()
+                );
                 warn!("Message was ignored");
-                None                
+                None
             }
         } else {
             None
@@ -233,9 +236,9 @@ impl TetherAgent {
                 panic!("You cannot publish using an Input Plug")
             }
             PlugDefinition::OutputPlugDefinition(output_plug_definition) => {
-                let PlugDefinitionCommon { three_part_topic, qos, .. } = &plug_definition.common();
+                let PlugDefinitionCommon { topic, qos, .. } = &plug_definition.common();
                 let message = MessageBuilder::new()
-                    .topic(three_part_topic.topic())
+                    .topic(topic)
                     .payload(payload.unwrap_or(&[]))
                     .retained(output_plug_definition.retain())
                     .qos(*qos)

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -50,24 +50,14 @@ impl TetherAgentOptionsBuilder {
         }
     }
 
-    pub fn id(mut self, id: &str) -> Self {
-        self.id = Some(id.into());
-        self
-    }
-
     /// Provide Some(value) to override or None to use default
-    pub fn id_optional(mut self, id: Option<String>) -> Self {
+    pub fn id(mut self, id: Option<String>) -> Self {
         self.id = convert_optional(id);
         self
     }
 
-    pub fn host(mut self, host: &str) -> Self {
-        self.host = Some(host.into());
-        self
-    }
-
     /// Provide Some(value) to override or None to use default
-    pub fn host_optional(mut self, host: Option<String>) -> Self {
+    pub fn host(mut self, host: Option<String>) -> Self {
         self.host = convert_optional(host);
         self
     }
@@ -77,24 +67,14 @@ impl TetherAgentOptionsBuilder {
         self
     }
 
-    pub fn username(mut self, username: &str) -> Self {
-        self.username = Some(username.into());
-        self
-    }
-
     /// Provide Some(value) to override or None to use default
-    pub fn username_optional(mut self, username: Option<String>) -> Self {
+    pub fn username(mut self, username: Option<String>) -> Self {
         self.username = convert_optional(username);
         self
     }
 
-    pub fn password(mut self, password: &str) -> Self {
-        self.password = Some(password.into());
-        self
-    }
-
     /// Provide Some(value) to override or None to use default
-    pub fn password_optional(mut self, password: Option<String>) -> Self {
+    pub fn password(mut self, password: Option<String>) -> Self {
         self.password = convert_optional(password);
         self
     }

--- a/base_agent/rs/src/lib.rs
+++ b/base_agent/rs/src/lib.rs
@@ -1,38 +1,6 @@
-pub use agent::*;
-pub use paho_mqtt as mqtt;
-pub use plugs::*;
-
 pub mod agent;
 pub mod plugs;
 
-pub fn parse_plug_name(topic: &str) -> Option<&str> {
-    let parts: Vec<&str> = topic.split('/').collect();
-    match parts.get(2) {
-        Some(s) => Some(*s),
-        None => None,
-    }
-}
-
-pub fn parse_agent_id(topic: &str) -> Option<&str> {
-    let parts: Vec<&str> = topic.split('/').collect();
-    match parts.get(1) {
-        Some(s) => Some(*s),
-        None => None,
-    }
-}
-
-pub fn parse_agent_role(topic: &str) -> Option<&str> {
-    let parts: Vec<&str> = topic.split('/').collect();
-    match parts.first() {
-        Some(s) => Some(*s),
-        None => None,
-    }
-}
-
-pub fn build_topic(role: &str, id: &str, plug_name: &str) -> String {
-    format!("{role}/{id}/{plug_name}")
-}
-
-pub fn default_subscribe_topic(plug_name: &str) -> String {
-    format!("+/+/{plug_name}")
-}
+pub use agent::*;
+pub use paho_mqtt as mqtt;
+pub use plugs::*;

--- a/base_agent/rs/src/plugs/definitions.rs
+++ b/base_agent/rs/src/plugs/definitions.rs
@@ -125,27 +125,7 @@ pub enum PlugDefinition {
     OutputPlug(OutputPlugDefinition),
 }
 
-// #[derive(Serialize, Deserialize, Debug)]
-// pub enum PlugDefinition {
-//     InputPlugDefinition(InputPlugDefinition),
-//     OutputPlugDefinition(OutputPlugDefinition),
-// }
-
 impl PlugDefinition {
-    //     pub fn common(&self) -> &PlugDefinitionCommon {
-    //         match self {
-    //             PlugDefinition::InputPlugDefinition(plug) => &plug.common,
-    //             PlugDefinition::OutputPlugDefinition(plug) => &plug.common,
-    //         }
-    //     }
-
-    //     pub fn common_mut(&mut self) -> &mut PlugDefinitionCommon {
-    //         match self {
-    //             PlugDefinition::InputPlugDefinition(plug) => &mut plug.common,
-    //             PlugDefinition::OutputPlugDefinition(plug) => &mut plug.common,
-    //         }
-    //     }
-
     pub fn name(&self) -> &str {
         match self {
             PlugDefinition::InputPlug(p) => &p.name(),

--- a/base_agent/rs/src/plugs/definitions.rs
+++ b/base_agent/rs/src/plugs/definitions.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PlugDefinitionCommon {
+    pub name: String,
+    pub topic: String,
+    pub qos: i32,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct InputPlugDefinition {
+    pub common: PlugDefinitionCommon,
+}
+
+impl InputPlugDefinition {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OutputPlugDefinition {
+    pub common: PlugDefinitionCommon,
+    pub retain: bool,
+}
+
+impl OutputPlugDefinition {
+    pub fn retain(&self) -> bool {
+        self.retain
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum PlugDefinition {
+    InputPlugDefinition(InputPlugDefinition),
+    OutputPlugDefinition(OutputPlugDefinition),
+}
+
+impl PlugDefinition {
+    pub fn common(&self) -> &PlugDefinitionCommon {
+        match self {
+            PlugDefinition::InputPlugDefinition(plug) => &plug.common,
+            PlugDefinition::OutputPlugDefinition(plug) => &plug.common,
+        }
+    }
+
+    pub fn common_mut(&mut self) -> &mut PlugDefinitionCommon {
+        match self {
+            PlugDefinition::InputPlugDefinition(plug) => &mut plug.common,
+            PlugDefinition::OutputPlugDefinition(plug) => &mut plug.common,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.common().name
+    }
+
+    pub fn topic(&self) -> &str {
+        &self.common().topic
+    }
+}

--- a/base_agent/rs/src/plugs/definitions.rs
+++ b/base_agent/rs/src/plugs/definitions.rs
@@ -1,25 +1,119 @@
+use log::{error, warn};
 use serde::{Deserialize, Serialize};
 
+use crate::three_part_topic::ThreePartTopic;
+
+pub trait PlugDefinitionCommon<'a> {
+    fn name(&'a self) -> &'a str;
+    fn topic(&'a self) -> String;
+    fn qos(&'a self) -> i32;
+}
+
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PlugDefinitionCommon {
-    pub name: String,
-    pub topic: String,
-    pub qos: i32,
+pub enum TetherOrCustomTopic {
+    Tether(ThreePartTopic),
+    Custom(String),
 }
 #[derive(Serialize, Deserialize, Debug)]
 pub struct InputPlugDefinition {
-    pub common: PlugDefinitionCommon,
+    name: String,
+    topic: TetherOrCustomTopic,
+    qos: i32,
 }
 
-impl InputPlugDefinition {}
+impl<'a> PlugDefinitionCommon<'_> for InputPlugDefinition {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn topic(&self) -> String {
+        match &self.topic {
+            TetherOrCustomTopic::Custom(s) => s.into(),
+            TetherOrCustomTopic::Tether(t) => t.topic().into(),
+        }
+    }
+
+    fn qos(&self) -> i32 {
+        self.qos
+    }
+}
+
+impl InputPlugDefinition {
+    pub fn new(name: &str, topic: TetherOrCustomTopic, qos: Option<i32>) -> InputPlugDefinition {
+        InputPlugDefinition {
+            name: String::from(name),
+            topic,
+            qos: qos.unwrap_or(1),
+        }
+    }
+
+    pub fn matches(&self, topic: &str) -> bool {
+        match &self.topic {
+            TetherOrCustomTopic::Custom(s) => {
+                warn!(
+                    "Custom topic \"{}\" on Plug \"{}\" cannot be matched automatically; please filter manually for this",
+                    &s,
+                    self.name()
+                );
+                true
+            }
+            TetherOrCustomTopic::Tether(my_tpt) => {
+                if let Ok(incoming_three_parts) = ThreePartTopic::try_from(topic) {
+                    let matches_role =
+                        my_tpt.role() == "+" || my_tpt.role().eq(incoming_three_parts.role());
+                    let matches_id =
+                        my_tpt.id() == "+" || my_tpt.id().eq(incoming_three_parts.id());
+                    let matches_plug_name = my_tpt.plug_name().eq(incoming_three_parts.plug_name());
+                    matches_role && matches_id && matches_plug_name
+                } else {
+                    error!("Incoming topic \"{}\" is not a three-part topic", topic);
+                    false
+                }
+            }
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OutputPlugDefinition {
-    pub common: PlugDefinitionCommon,
-    pub retain: bool,
+    name: String,
+    topic: TetherOrCustomTopic,
+    qos: i32,
+    retain: bool,
+}
+
+impl PlugDefinitionCommon<'_> for OutputPlugDefinition {
+    fn name(&'_ self) -> &'_ str {
+        &self.name
+    }
+
+    fn topic(&self) -> String {
+        match &self.topic {
+            TetherOrCustomTopic::Custom(s) => s.into(),
+            TetherOrCustomTopic::Tether(t) => t.topic().into(),
+        }
+    }
+
+    fn qos(&'_ self) -> i32 {
+        self.qos
+    }
 }
 
 impl OutputPlugDefinition {
+    pub fn new(
+        name: &str,
+        topic: TetherOrCustomTopic,
+        qos: Option<i32>,
+        retain: Option<bool>,
+    ) -> OutputPlugDefinition {
+        OutputPlugDefinition {
+            name: String::from(name),
+            topic,
+            qos: qos.unwrap_or(1),
+            retain: retain.unwrap_or(false),
+        }
+    }
+
     pub fn retain(&self) -> bool {
         self.retain
     }
@@ -27,30 +121,52 @@ impl OutputPlugDefinition {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PlugDefinition {
-    InputPlugDefinition(InputPlugDefinition),
-    OutputPlugDefinition(OutputPlugDefinition),
+    InputPlug(InputPlugDefinition),
+    OutputPlug(OutputPlugDefinition),
 }
 
-impl PlugDefinition {
-    pub fn common(&self) -> &PlugDefinitionCommon {
-        match self {
-            PlugDefinition::InputPlugDefinition(plug) => &plug.common,
-            PlugDefinition::OutputPlugDefinition(plug) => &plug.common,
-        }
-    }
+// #[derive(Serialize, Deserialize, Debug)]
+// pub enum PlugDefinition {
+//     InputPlugDefinition(InputPlugDefinition),
+//     OutputPlugDefinition(OutputPlugDefinition),
+// }
 
-    pub fn common_mut(&mut self) -> &mut PlugDefinitionCommon {
-        match self {
-            PlugDefinition::InputPlugDefinition(plug) => &mut plug.common,
-            PlugDefinition::OutputPlugDefinition(plug) => &mut plug.common,
-        }
-    }
+impl PlugDefinition {
+    //     pub fn common(&self) -> &PlugDefinitionCommon {
+    //         match self {
+    //             PlugDefinition::InputPlugDefinition(plug) => &plug.common,
+    //             PlugDefinition::OutputPlugDefinition(plug) => &plug.common,
+    //         }
+    //     }
+
+    //     pub fn common_mut(&mut self) -> &mut PlugDefinitionCommon {
+    //         match self {
+    //             PlugDefinition::InputPlugDefinition(plug) => &mut plug.common,
+    //             PlugDefinition::OutputPlugDefinition(plug) => &mut plug.common,
+    //         }
+    //     }
 
     pub fn name(&self) -> &str {
-        &self.common().name
+        match self {
+            PlugDefinition::InputPlug(p) => &p.name(),
+            PlugDefinition::OutputPlug(p) => &p.name(),
+        }
     }
 
-    pub fn topic(&self) -> &str {
-        &self.common().topic
+    pub fn topic(&self) -> String {
+        match self {
+            PlugDefinition::InputPlug(p) => p.topic(),
+            PlugDefinition::OutputPlug(p) => p.topic(),
+        }
+    }
+
+    pub fn matches(&self, topic: &str) -> bool {
+        match self {
+            PlugDefinition::InputPlug(p) => p.matches(topic),
+            PlugDefinition::OutputPlug(_) => {
+                error!("We don't check matches for Output Plugs");
+                false
+            }
+        }
     }
 }

--- a/base_agent/rs/src/plugs/mod.rs
+++ b/base_agent/rs/src/plugs/mod.rs
@@ -1,109 +1,13 @@
 use crate::*;
-use anyhow::anyhow;
 use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 
 pub mod definitions;
 pub mod options;
+pub mod three_part_topic;
 
 pub use definitions::*;
 pub use options::*;
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ThreePartTopic {
-    role: String,
-    id: String,
-    plug_name: String,
-}
-
-impl ThreePartTopic {
-    /// Publish topics fall back to the ID and/or role associated with the agent, if not explicitly provided
-    // pub fn new_for_publish(
-    //     role: Option<&str>,
-    //     id: Option<&str>,
-    //     plug_name: &str,
-    //     agent: &TetherAgent,
-    // ) -> ThreePartTopic {
-    //     ThreePartTopic {
-    //         role: String::from(role.unwrap_or(agent.role())),
-    //         id: String::from(role.unwrap_or(agent.id())),
-    //         plug_name: String::from(plug_name),
-    //     }
-    // }
-
-    // /// Subscribe topics fall back to wildcard `+` for role and/or id if not explicitly provided
-    // pub fn new_for_subscribe(
-    //     role: Option<&str>,
-    //     id: Option<&str>,
-    //     plug_name: &str,
-    // ) -> ThreePartTopic {
-    //     ThreePartTopic {
-    //         role: String::from(role.unwrap_or("+")),
-    //         id: String::from(role.unwrap_or("+")),
-    //         plug_name: String::from(plug_name),
-    //     }
-    // }
-
-    pub fn new(role: &str, id: &str, plug_name: &str) -> ThreePartTopic {
-        ThreePartTopic {
-            role: role.into(),
-            id: id.into(),
-            plug_name: plug_name.into(),
-        }
-    }
-
-    pub fn topic(&self) -> String {
-        build_topic(&self.role, &self.id, &self.plug_name)
-    }
-
-    pub fn role(&self) -> &str {
-        &self.role
-    }
-
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-
-    pub fn plug_name(&self) -> &str {
-        &self.plug_name
-    }
-
-    pub fn set_role(&mut self, role: &str) {
-        self.role = role.into();
-    }
-
-    pub fn set_id(&mut self, id: &str) {
-        self.id = id.into();
-    }
-
-    pub fn set_plug_name(&mut self, plug_name: &str) {
-        self.plug_name = plug_name.into();
-    }
-}
-
-impl TryFrom<&str> for ThreePartTopic {
-    type Error = anyhow::Error;
-
-    /// Try to convert a topic string into a valid Tether Three Part Topic
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let parts = value.split('/').collect::<Vec<&str>>();
-
-        if parts.len() != 3 {
-            return Err(anyhow!(
-                "Did not find exactly three parts in the topic {}",
-                value
-            ));
-        } else {
-            debug!("parts: {:?}", parts);
-        }
-
-        let role = parts.get(0).expect("the role part should exist");
-        let id = parts.get(1).expect("the id part should exist");
-        let plug_name = parts.get(2).expect("the plug_name part should exist");
-
-        return Ok(ThreePartTopic::new(role, id, plug_name));
-    }
-}
 
 // pub fn parse_plug_name(topic: &str) -> Option<&str> {
 //     let parts: Vec<&str> = topic.split('/').collect();
@@ -128,10 +32,6 @@ impl TryFrom<&str> for ThreePartTopic {
 //         None => None,
 //     }
 // }
-
-fn build_topic(role: &str, id: &str, plug_name: &str) -> String {
-    format!("{role}/{id}/{plug_name}")
-}
 
 // pub fn default_subscribe_topic(plug_name: &str) -> String {
 //     format!("+/+/{plug_name}")

--- a/base_agent/rs/src/plugs/mod.rs
+++ b/base_agent/rs/src/plugs/mod.rs
@@ -84,6 +84,7 @@ impl ThreePartTopic {
 impl TryFrom<&str> for ThreePartTopic {
     type Error = anyhow::Error;
 
+    /// Try to convert a topic string into a valid Tether Three Part Topic
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let parts = value.split('/').collect::<Vec<&str>>();
 
@@ -96,9 +97,9 @@ impl TryFrom<&str> for ThreePartTopic {
             debug!("parts: {:?}", parts);
         }
 
-        let role = parts.get(0).expect("this part should exist");
-        let id = parts.get(1).expect("this part should exist");
-        let plug_name = parts.get(2).expect("this part should exist");
+        let role = parts.get(0).expect("the role part should exist");
+        let id = parts.get(1).expect("the id part should exist");
+        let plug_name = parts.get(2).expect("the plug_name part should exist");
 
         return Ok(ThreePartTopic::new(role, id, plug_name));
     }
@@ -135,13 +136,6 @@ fn build_topic(role: &str, id: &str, plug_name: &str) -> String {
 // pub fn default_subscribe_topic(plug_name: &str) -> String {
 //     format!("+/+/{plug_name}")
 // }
-
-#[derive(Debug)]
-enum TetherOrCustomTopic {
-    NotSet(),
-    TetherTopic(ThreePartTopic),
-    CustomTopic(String),
-}
 
 // #[derive(Debug)]
 // struct PlugOptionsCommon {

--- a/base_agent/rs/src/plugs/mod.rs
+++ b/base_agent/rs/src/plugs/mod.rs
@@ -1,7 +1,13 @@
 use crate::*;
-use log::{debug, error};
-use serde::{Deserialize, Serialize};
 use anyhow::anyhow;
+use log::{debug, error, warn};
+use serde::{Deserialize, Serialize};
+
+pub mod definitions;
+pub mod options;
+
+pub use definitions::*;
+pub use options::*;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ThreePartTopic {
@@ -11,26 +17,43 @@ pub struct ThreePartTopic {
 }
 
 impl ThreePartTopic {
-
     /// Publish topics fall back to the ID and/or role associated with the agent, if not explicitly provided
-    pub fn new_for_publish (role: Option<String>, id: Option<String>, plug_name: &str, agent: &TetherAgent) -> ThreePartTopic {
-        ThreePartTopic { role: role.unwrap_or(agent.role().into()), id: id.unwrap_or(agent.id().into()), plug_name: plug_name.into() }
-    }   
+    // pub fn new_for_publish(
+    //     role: Option<&str>,
+    //     id: Option<&str>,
+    //     plug_name: &str,
+    //     agent: &TetherAgent,
+    // ) -> ThreePartTopic {
+    //     ThreePartTopic {
+    //         role: String::from(role.unwrap_or(agent.role())),
+    //         id: String::from(role.unwrap_or(agent.id())),
+    //         plug_name: String::from(plug_name),
+    //     }
+    // }
 
-    /// Subscribe topics fall back to wildcard `+` for role and/or id if not explicitly provided
-    pub fn new_for_subscribe (role: Option<String>, id: Option<String>, plug_name: String) -> ThreePartTopic {
-        ThreePartTopic { role: role.unwrap_or("+".into()), id: id.unwrap_or("+".into()), plug_name: plug_name.into() }
+    // /// Subscribe topics fall back to wildcard `+` for role and/or id if not explicitly provided
+    // pub fn new_for_subscribe(
+    //     role: Option<&str>,
+    //     id: Option<&str>,
+    //     plug_name: &str,
+    // ) -> ThreePartTopic {
+    //     ThreePartTopic {
+    //         role: String::from(role.unwrap_or("+")),
+    //         id: String::from(role.unwrap_or("+")),
+    //         plug_name: String::from(plug_name),
+    //     }
+    // }
+
+    pub fn new(role: &str, id: &str, plug_name: &str) -> ThreePartTopic {
+        ThreePartTopic {
+            role: role.into(),
+            id: id.into(),
+            plug_name: plug_name.into(),
+        }
     }
 
-    fn new (role: &str, id: &str, plug_name: &str) -> ThreePartTopic {
-        ThreePartTopic { role: role.into(), id: id.into(), plug_name: plug_name.into() }
-    }
-
-    /// Turn the ThreePartTopic back into an actual topic string. This is rebuilt (and the String is reallocated)
-    /// each time the function is called, using the role + ID + plug_name parts. In other words, at no point do we 
-    /// retain complete topic string internally.
     pub fn topic(&self) -> String {
-        format!("{}/{}/{}", &self.role, &self.id, &self.plug_name)
+        build_topic(&self.role, &self.id, &self.plug_name)
     }
 
     pub fn role(&self) -> &str {
@@ -56,27 +79,28 @@ impl ThreePartTopic {
     pub fn set_plug_name(&mut self, plug_name: &str) {
         self.plug_name = plug_name.into();
     }
-
-
 }
 
 impl TryFrom<&str> for ThreePartTopic {
     type Error = anyhow::Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-
         let parts = value.split('/').collect::<Vec<&str>>();
 
         if parts.len() != 3 {
-            return Err(anyhow!("Did not find exactly three parts in the topic {}", value));
+            return Err(anyhow!(
+                "Did not find exactly three parts in the topic {}",
+                value
+            ));
+        } else {
+            debug!("parts: {:?}", parts);
         }
 
         let role = parts.get(0).expect("this part should exist");
         let id = parts.get(1).expect("this part should exist");
-        let plug_name = parts.get(3).expect("this part should exist");
+        let plug_name = parts.get(2).expect("this part should exist");
 
         return Ok(ThreePartTopic::new(role, id, plug_name));
-
     }
 }
 
@@ -104,213 +128,36 @@ impl TryFrom<&str> for ThreePartTopic {
 //     }
 // }
 
-// pub fn build_topic(role: &str, id: &str, plug_name: &str) -> String {
-//     format!("{role}/{id}/{plug_name}")
-// }
+fn build_topic(role: &str, id: &str, plug_name: &str) -> String {
+    format!("{role}/{id}/{plug_name}")
+}
 
 // pub fn default_subscribe_topic(plug_name: &str) -> String {
 //     format!("+/+/{plug_name}")
 // }
 
 #[derive(Debug)]
-struct PlugOptionsCommon {
-    pub name: String,
-    pub role_override: Option<String>,
-    pub id_override: Option<String>,
-    pub qos: Option<i32>,
+enum TetherOrCustomTopic {
+    NotSet(),
+    TetherTopic(ThreePartTopic),
+    CustomTopic(String),
 }
 
-impl PlugOptionsCommon {
-    fn new(name: &str) -> Self {
-        PlugOptionsCommon {
-            name: name.into(),
-            role_override: None,
-            id_override: None,
-            qos: None,
-        }
-    }
-}
+// #[derive(Debug)]
+// struct PlugOptionsCommon {
+//     pub name: String,
+//     pub topic: TetherOrCustomTopic,
+//     // pub role_override: Option<String>,
+//     // pub id_override: Option<String>,
+//     pub qos: Option<i32>,
+// }
 
-
-pub struct InputPlugOptions {
-    common: PlugOptionsCommon,
-}
-
-pub struct OutputPlugOptions {
-    common: PlugOptionsCommon,
-    retain: Option<bool>,
-}
-
-/// This is the definition of an Input or Output Plug
-/// You should never use this directly; call build()
-/// to get a usable Plug
-pub enum PlugOptionsBuilder {
-    InputPlugOptions(InputPlugOptions),
-    OutputPlugOptions(OutputPlugOptions),
-}
-
-
-
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PlugDefinitionCommon {
-    pub name: String,
-    pub three_part_topic: ThreePartTopic,
-    pub qos: i32,
-}
-#[derive(Serialize, Deserialize, Debug)]
-pub struct InputPlugDefinition {
-    common: PlugDefinitionCommon,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct OutputPlugDefinition {
-    common: PlugDefinitionCommon,
-    retain: bool,
-}
-
-impl OutputPlugDefinition {
-    pub fn retain(&self) -> bool {
-        self.retain
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum PlugDefinition {
-    InputPlugDefinition(InputPlugDefinition),
-    OutputPlugDefinition(OutputPlugDefinition),
-}
-
-impl PlugDefinition {
-    pub fn common(&self) -> &PlugDefinitionCommon {
-        match self {
-            PlugDefinition::InputPlugDefinition(plug) => &plug.common,
-            PlugDefinition::OutputPlugDefinition(plug) => &plug.common,
-        }
-    }
-
-    pub fn common_mut(&mut self) -> &mut PlugDefinitionCommon {
-        match self {
-            PlugDefinition::InputPlugDefinition(plug) => &mut plug.common,
-            PlugDefinition::OutputPlugDefinition(plug) => &mut plug.common,
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        &self.common().name
-    }
-
-    pub fn topic(&self) -> &ThreePartTopic {
-        &self.common().three_part_topic
-    }
-}
-
-impl PlugOptionsBuilder {
-    fn common(&mut self) -> &mut PlugOptionsCommon {
-        match self {
-            PlugOptionsBuilder::InputPlugOptions(plug) => &mut plug.common,
-            PlugOptionsBuilder::OutputPlugOptions(plug) => &mut plug.common,
-        }
-    }
-
-    pub fn create_input(name: &str) -> PlugOptionsBuilder {
-        PlugOptionsBuilder::InputPlugOptions(InputPlugOptions {
-            common: PlugOptionsCommon::new(name),
-        })
-    }
-
-    pub fn create_output(name: &str) -> PlugOptionsBuilder {
-        PlugOptionsBuilder::OutputPlugOptions(OutputPlugOptions {
-            common: PlugOptionsCommon::new(name),
-            retain: Some(false),
-        })
-    }
-
-    pub fn qos(mut self, qos: i32) -> Self {
-        self.common().qos = Some(qos);
-        self
-    }
-
-    pub fn set_role(mut self, role: &str) -> Self {
-        self.common().role_override = Some(role.into());
-        self
-    }
-
-    pub fn set_id(mut self, id: &str) -> Self {
-        self.common().id_override = Some(id.into());
-        self
-    }
-
-    pub fn topic(mut self, override_topic: &str) -> Self {
-        if let Ok(three_part_topic) = TryInto::<ThreePartTopic>::try_into(override_topic) {
-            self.common().role_override = Some(three_part_topic.role().into());
-            self.common().id_override = Some(three_part_topic.id().into());
-        } else {
-            error!("Invalid topic; could not convert into Tether 3 Part Topic");
-        }
-        self
-    }
-
-    pub fn retain(self, should_retain: bool) -> Self {
-        match self {
-            Self::InputPlugOptions(_) => {
-                panic!("Cannot set retain flag on Input Plug / subscription")
-            }
-            Self::OutputPlugOptions(plug) => {
-                PlugOptionsBuilder::OutputPlugOptions(OutputPlugOptions {
-                    common: plug.common,
-                    retain: Some(should_retain),
-                })
-            }
-        }
-    }
-
-    pub fn build(self, tether_agent: &TetherAgent) -> anyhow::Result<PlugDefinition> {
-        match self {
-            Self::InputPlugOptions(plug) => {
-                let three_part_topic = ThreePartTopic::new_for_subscribe(
-                    plug.common.role_override.and_then(|s| Some(s)), 
-                    plug.common.id_override.and_then(|s| Some(s)), 
-                    plug.common.name.clone(),
-                );
-                let final_qos = plug.common.qos.unwrap_or(1);
-                debug!(
-                    "Attempt to subscribe for plug named {} ...",
-                    &three_part_topic.topic()
-                );
-                let topic_string = three_part_topic.topic();
-                match tether_agent.client().subscribe(&topic_string, final_qos) {
-                    Ok(res) => {
-                        debug!("This topic was fine: \"{topic_string}\"", );
-                        debug!("Server respond OK for subscribe: {res:?}");
-                        Ok(PlugDefinition::InputPlugDefinition(InputPlugDefinition {
-                            common: PlugDefinitionCommon {
-                                name: plug.common.name,
-                                three_part_topic,
-                                qos: final_qos,
-                            },
-                        }))
-                    }
-                    Err(e) => Err(e.into()),
-                }
-            }
-            Self::OutputPlugOptions(plug) => {
-                let three_part_topic = ThreePartTopic::new_for_publish(
-                    plug.common.role_override.and_then(|s| Some(s)),
-                    plug.common.id_override.and_then(|s| Some(s)), 
-                    &plug.common.name, tether_agent);
-
-                let final_qos = plug.common.qos.unwrap_or(1);
-
-                Ok(PlugDefinition::OutputPlugDefinition(OutputPlugDefinition {
-                    common: PlugDefinitionCommon {
-                        name: plug.common.name,
-                        three_part_topic,
-                        qos: final_qos,
-                    },
-                    retain: plug.retain.unwrap_or(false),
-                }))
-            }
-        }
-    }
-}
+// impl PlugOptionsCommon {
+//     fn new(name: &str) -> Self {
+//         PlugOptionsCommon {
+//             name: name.into(),
+//             topic:
+//             qos: None,
+//         }
+//     }
+// }

--- a/base_agent/rs/src/plugs/mod.rs
+++ b/base_agent/rs/src/plugs/mod.rs
@@ -1,57 +1,6 @@
-use crate::*;
-use log::{debug, error, warn};
-use serde::{Deserialize, Serialize};
-
 pub mod definitions;
 pub mod options;
 pub mod three_part_topic;
 
 pub use definitions::*;
 pub use options::*;
-
-// pub fn parse_plug_name(topic: &str) -> Option<&str> {
-//     let parts: Vec<&str> = topic.split('/').collect();
-//     match parts.get(2) {
-//         Some(s) => Some(*s),
-//         None => None,
-//     }
-// }
-
-// pub fn parse_agent_id(topic: &str) -> Option<&str> {
-//     let parts: Vec<&str> = topic.split('/').collect();
-//     match parts.get(1) {
-//         Some(s) => Some(*s),
-//         None => None,
-//     }
-// }
-
-// pub fn parse_agent_role(topic: &str) -> Option<&str> {
-//     let parts: Vec<&str> = topic.split('/').collect();
-//     match parts.first() {
-//         Some(s) => Some(*s),
-//         None => None,
-//     }
-// }
-
-// pub fn default_subscribe_topic(plug_name: &str) -> String {
-//     format!("+/+/{plug_name}")
-// }
-
-// #[derive(Debug)]
-// struct PlugOptionsCommon {
-//     pub name: String,
-//     pub topic: TetherOrCustomTopic,
-//     // pub role_override: Option<String>,
-//     // pub id_override: Option<String>,
-//     pub qos: Option<i32>,
-// }
-
-// impl PlugOptionsCommon {
-//     fn new(name: &str) -> Self {
-//         PlugOptionsCommon {
-//             name: name.into(),
-//             topic:
-//             qos: None,
-//         }
-//     }
-// }

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -1,0 +1,168 @@
+use log::{debug, error, info, warn};
+
+use crate::{
+    definitions::{
+        InputPlugDefinition, OutputPlugDefinition, PlugDefinition, PlugDefinitionCommon,
+    },
+    TetherAgent, ThreePartTopic,
+};
+
+pub struct InputPlugOptions {
+    plug_name: String,
+    qos: Option<i32>,
+    override_subscribe_role: Option<String>,
+    override_subscribe_id: Option<String>,
+    override_topic: Option<String>,
+}
+
+pub struct OutputPlugOptions {
+    plug_name: String,
+    qos: Option<i32>,
+    override_publish_role: Option<String>,
+    override_publish_id: Option<String>,
+    override_topic: Option<String>,
+    retain: Option<bool>,
+}
+
+/// This is the definition of an Input or Output Plug
+/// You should never use this directly; call build()
+/// to get a usable Plug
+pub enum PlugOptionsBuilder {
+    InputPlugOptions(InputPlugOptions),
+    OutputPlugOptions(OutputPlugOptions),
+}
+
+impl PlugOptionsBuilder {
+    pub fn create_input(name: &str) -> PlugOptionsBuilder {
+        PlugOptionsBuilder::InputPlugOptions(InputPlugOptions {
+            plug_name: String::from(name),
+            override_subscribe_id: None,
+            override_subscribe_role: None,
+            override_topic: None,
+            qos: None,
+        })
+    }
+
+    pub fn create_output(name: &str) -> PlugOptionsBuilder {
+        PlugOptionsBuilder::OutputPlugOptions(OutputPlugOptions {
+            plug_name: String::from(name),
+            override_publish_id: None,
+            override_publish_role: None,
+            override_topic: None,
+            qos: None,
+            retain: None,
+        })
+    }
+
+    pub fn qos(mut self, qos: i32) -> Self {
+        match &mut self {
+            PlugOptionsBuilder::InputPlugOptions(s) => s.qos = Some(qos),
+            PlugOptionsBuilder::OutputPlugOptions(s) => s.qos = Some(qos),
+        };
+        self
+    }
+
+    pub fn topic(mut self, override_topic: &str) -> Self {
+        if TryInto::<ThreePartTopic>::try_into(override_topic).is_ok() {
+            info!("Custom topic passes Three Part Topic validation");
+        } else {
+            warn!(
+                "Could not convert \"{}\" into Tether 3 Part Topic; presumably you know what you're doing!",
+                override_topic
+            );
+        }
+        match &mut self {
+            PlugOptionsBuilder::InputPlugOptions(s) => {
+                s.override_topic = Some(override_topic.into())
+            }
+            PlugOptionsBuilder::OutputPlugOptions(s) => {
+                s.override_topic = Some(override_topic.into())
+            }
+        };
+        self
+    }
+
+    pub fn retain(mut self, should_retain: bool) -> Self {
+        match &mut self {
+            Self::InputPlugOptions(_) => {
+                error!("Cannot set retain flag on Input Plug / subscription");
+            }
+            Self::OutputPlugOptions(s) => {
+                s.retain = Some(should_retain);
+            }
+        }
+        self
+    }
+
+    pub fn build(self, tether_agent: &TetherAgent) -> anyhow::Result<PlugDefinition> {
+        match self {
+            Self::InputPlugOptions(plug_options) => {
+                let final_topic: String = match plug_options.override_topic {
+                    Some(s) => s,
+                    None => {
+                        let t = ThreePartTopic::new(
+                            &plug_options
+                                .override_subscribe_role
+                                .unwrap_or("+".to_string()),
+                            &plug_options
+                                .override_subscribe_id
+                                .unwrap_or("+".to_string()),
+                            &plug_options.plug_name,
+                        );
+                        t.topic()
+                    }
+                };
+                let final_qos = plug_options.qos.unwrap_or(1);
+                debug!(
+                    "Attempt to subscribe for plug named \"{}\" with topic \"{}\" ...",
+                    &plug_options.plug_name, &final_topic
+                );
+                match tether_agent.client().subscribe(&final_topic, final_qos) {
+                    Ok(res) => {
+                        debug!("This topic was fine: \"{final_topic}\"",);
+                        debug!("Server respond OK for subscribe: {res:?}");
+                        Ok(PlugDefinition::InputPlugDefinition(InputPlugDefinition {
+                            common: PlugDefinitionCommon {
+                                name: plug_options.plug_name,
+                                qos: final_qos,
+                                topic: final_topic,
+                            },
+                        }))
+                    }
+                    Err(e) => Err(e.into()),
+                }
+            }
+            Self::OutputPlugOptions(plug_options) => {
+                let final_topic: String = match plug_options.override_topic {
+                    Some(s) => s,
+                    None => {
+                        let t = ThreePartTopic::new(
+                            &plug_options
+                                .override_publish_role
+                                .unwrap_or(tether_agent.id().to_string()),
+                            &plug_options
+                                .override_publish_id
+                                .unwrap_or(tether_agent.id().to_string()),
+                            &plug_options.plug_name,
+                        );
+                        t.topic()
+                    }
+                };
+
+                let final_qos = plug_options.qos.unwrap_or(1);
+
+                debug!("Creating plug definition (immediately) for plug named \"{}\" with topic \"{}\"", 
+              &plug_options.plug_name, &final_topic);
+
+                Ok(PlugDefinition::OutputPlugDefinition(OutputPlugDefinition {
+                    common: PlugDefinitionCommon {
+                        name: plug_options.plug_name,
+                        topic: final_topic,
+                        qos: final_qos,
+                    },
+                    retain: plug_options.retain.unwrap_or(false),
+                }))
+            }
+        }
+    }
+}

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -119,7 +119,7 @@ impl PlugOptionsBuilder {
 
     /// Override the final topic to use for publishing or subscribing. The provided topic **will** be checked
     /// against the Tether Three Part Topic convention, but the function **will not** reject topic strings - just
-    /// produce a warning. It's therefore valid to use a wildcard such as "#".
+    /// produce a warning. It's therefore valid to use a wildcard such as "#", for Input (subscribing).
     ///
     /// Any customisations specified using `.role(...)` or `.id(...)` will be ignored if this function is called.
     pub fn topic(mut self, override_topic: Option<String>) -> Self {

--- a/base_agent/rs/src/plugs/three_part_topic.rs
+++ b/base_agent/rs/src/plugs/three_part_topic.rs
@@ -1,0 +1,125 @@
+use anyhow::anyhow;
+use log::debug;
+use serde::{Deserialize, Serialize};
+
+use crate::TetherAgent;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ThreePartTopic {
+    role: String,
+    id: String,
+    plug_name: String,
+    full_topic: String,
+}
+
+impl ThreePartTopic {
+    /// Publish topics fall back to the ID and/or role associated with the agent, if not explicitly provided
+    pub fn new_for_publish(
+        role: Option<String>,
+        id: Option<String>,
+        plug_name: &str,
+        agent: &TetherAgent,
+    ) -> ThreePartTopic {
+        let role = role.unwrap_or(agent.role().into());
+        let id = id.unwrap_or(agent.id().into());
+        let plug_name = String::from(plug_name);
+        let full_topic = build_topic(&role, &id, &plug_name);
+        ThreePartTopic {
+            role,
+            id,
+            plug_name,
+            full_topic,
+        }
+    }
+
+    /// Subscribe topics fall back to wildcard `+` for role and/or id if not explicitly provided
+    pub fn new_for_subscribe(
+        role: Option<String>,
+        id: Option<String>,
+        plug_name: &str,
+    ) -> ThreePartTopic {
+        let role = role.unwrap_or("+".into());
+        let id = id.unwrap_or("+".into());
+        let plug_name = String::from(plug_name);
+        let full_topic = build_topic(&role, &id, &plug_name);
+
+        ThreePartTopic {
+            role,
+            id,
+            plug_name,
+            full_topic,
+        }
+    }
+
+    pub fn new(role: &str, id: &str, plug_name: &str) -> ThreePartTopic {
+        ThreePartTopic {
+            role: role.into(),
+            id: id.into(),
+            plug_name: plug_name.into(),
+            full_topic: build_topic(&role, &id, &plug_name),
+        }
+    }
+
+    pub fn topic(&self) -> &str {
+        &self.full_topic
+    }
+
+    pub fn role(&self) -> &str {
+        &self.role
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn plug_name(&self) -> &str {
+        &self.plug_name
+    }
+
+    pub fn set_role(&mut self, role: &str) {
+        self.role = role.into();
+        self.update_full_topic();
+    }
+
+    pub fn set_id(&mut self, id: &str) {
+        self.id = id.into();
+        self.update_full_topic();
+    }
+
+    pub fn set_plug_name(&mut self, plug_name: &str) {
+        self.plug_name = plug_name.into();
+        self.update_full_topic();
+    }
+
+    fn update_full_topic(&mut self) {
+        self.full_topic = build_topic(&self.role, &self.id, &self.plug_name);
+    }
+}
+
+impl TryFrom<&str> for ThreePartTopic {
+    type Error = anyhow::Error;
+
+    /// Try to convert a topic string into a valid Tether Three Part Topic
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let parts = value.split('/').collect::<Vec<&str>>();
+
+        if parts.len() != 3 {
+            return Err(anyhow!(
+                "Did not find exactly three parts in the topic {}",
+                value
+            ));
+        } else {
+            debug!("parts: {:?}", parts);
+        }
+
+        let role = parts.get(0).expect("the role part should exist");
+        let id = parts.get(1).expect("the id part should exist");
+        let plug_name = parts.get(2).expect("the plug_name part should exist");
+
+        return Ok(ThreePartTopic::new(role, id, plug_name));
+    }
+}
+
+fn build_topic(role: &str, id: &str, plug_name: &str) -> String {
+    format!("{role}/{id}/{plug_name}")
+}

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -742,8 +742,6 @@ dependencies = [
 [[package]]
 name = "tether-agent"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebdd57c587062a032caa9b48ddf2b6ae8648a3dfe2c0678e88ecfdc4e0066b5"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -13,8 +13,8 @@ name = "tether"
 
 
 [dependencies]
-# tether-agent = { path = "../../base_agent/rs"}
-tether-agent = "0.9"
+tether-agent = { path = "../../base_agent/rs" }
+# tether-agent = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 rmp-serde = "1.1.1"

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -1,6 +1,7 @@
 use std::{thread::spawn, time::SystemTime};
 
 use env_logger::{Builder, Env};
+use log::LevelFilter;
 use tether_agent::TetherAgentOptionsBuilder;
 use tether_utils::{
     tether_playback::{PlaybackOptions, TetherPlaybackUtil},
@@ -16,7 +17,10 @@ fn demo_receive() {
         .expect("failed to init/connect Tether Agent");
 
     let options = ReceiveOptions {
-        subscribe_topic: "#".into(),
+        subscribe_topic: None,
+        subscribe_role: None,
+        subscribe_id: None,
+        subscribe_plug: None,
     };
 
     receive(&options, &tether_agent, |_plug_name, message, decoded| {
@@ -33,8 +37,10 @@ fn demo_send() {
     let mut count = 0;
 
     let options = SendOptions {
-        plug_name: "dummyData".into(),
+        plug_name: Some("dummyData".into()),
         plug_topic: None,
+        plug_id: None,
+        plug_role: None,
         message_payload_json: None,
         use_dummy_data: true,
     };
@@ -171,6 +177,7 @@ fn main() {
     println!("Press Ctrl+C to stop");
 
     let mut env_builder = Builder::from_env(Env::default().default_filter_or("info"));
+    env_builder.filter_module("paho_mqtt", LevelFilter::Warn);
     env_builder.init();
 
     let handles = vec![

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -65,11 +65,11 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let tether_agent = TetherAgentOptionsBuilder::new(&cli.tether_role)
-        .id(&cli.tether_id)
-        .host(&cli.tether_host)
+        .id(Some(cli.tether_id.into()))
+        .host(Some(cli.tether_host.clone()))
         .port(cli.tether_port)
-        .username(&cli.tether_username)
-        .password(&cli.tether_password)
+        .username(Some(cli.tether_username.into()))
+        .password(Some(cli.tether_password.into()))
         .build()
         .unwrap_or_else(|_| {
             error!("Failed to initialise and/or connect the Tether Agent");

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -96,7 +96,7 @@ impl TetherRecordUtil {
         info!("Tether Record Utility: start recording");
 
         let _input = PlugOptionsBuilder::create_input("all")
-            .topic(&self.options.topic)
+            .topic(Some(self.options.topic.clone())) // TODO: should be possible to build TPT
             .build(tether_agent)
             .expect("failed to create input plug");
 

--- a/utilities/tether-utils/src/tether_send.rs
+++ b/utilities/tether-utils/src/tether_send.rs
@@ -44,23 +44,6 @@ struct DummyData {
 pub fn send(options: &SendOptions, tether_agent: &TetherAgent) -> anyhow::Result<()> {
     info!("Tether Send Utility");
 
-    let (role, id, _) = tether_agent.description();
-
-    // let publish_topic = match &options.plug_topic {
-    //     Some(override_topic) => {
-    //         warn!(
-    //             "Using override topic \"{}\"; agent role, agent ID and plug name will be ignored",
-    //             override_topic
-    //         );
-    //         String::from(override_topic)
-    //     }
-    //     None => {
-    //         let auto_generated_topic = build_topic(role, id, &options.plug_name);
-    //         info!("Using auto-generated topic \"{}\"", &auto_generated_topic);
-    //         auto_generated_topic
-    //     }
-    // };
-
     let plug_name = options.plug_name.clone().unwrap_or("testMessages".into());
 
     let output = PlugOptionsBuilder::create_output(&plug_name)
@@ -69,6 +52,8 @@ pub fn send(options: &SendOptions, tether_agent: &TetherAgent) -> anyhow::Result
         .topic(options.plug_topic.clone())
         .build(tether_agent)
         .expect("failed to create output plug");
+
+    info!("Sending on topic \"{}\" ...", output.topic());
 
     if options.use_dummy_data {
         let payload = DummyData {

--- a/utilities/tether-utils/src/tether_topics/agent_tree.rs
+++ b/utilities/tether-utils/src/tether_topics/agent_tree.rs
@@ -1,5 +1,6 @@
 use std::fmt;
-use tether_agent::{parse_agent_id, parse_plug_name};
+
+use super::{parse_agent_id, parse_agent_role, parse_plug_name};
 
 /// Role, IDs, OutputPlugs
 pub struct AgentTree {
@@ -11,8 +12,12 @@ pub struct AgentTree {
 impl AgentTree {
     pub fn new(role: &str, topics: &[String]) -> AgentTree {
         let topics_this_agent = topics.iter().filter_map(|topic| {
-            if topic.contains(role) {
-                Some(String::from(topic))
+            if let Some(role_part) = parse_agent_role(topic.as_str()) {
+                if role_part == role {
+                    Some(String::from(topic))
+                } else {
+                    None
+                }
             } else {
                 None
             }

--- a/utilities/tether-utils/src/tether_topics/insights.rs
+++ b/utilities/tether-utils/src/tether_topics/insights.rs
@@ -1,8 +1,5 @@
 use circular_buffer::CircularBuffer;
-use tether_agent::{
-    mqtt::Message, parse_agent_id, parse_agent_role, parse_plug_name, PlugOptionsBuilder,
-    TetherAgent,
-};
+use tether_agent::{mqtt::Message, PlugOptionsBuilder, TetherAgent};
 
 use crate::tether_topics::{agent_tree::AgentTree, sampler::Sampler};
 use std::{
@@ -10,7 +7,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use super::TopicOptions;
+use super::{parse_agent_id, parse_agent_role, parse_plug_name, TopicOptions};
 pub const MONITOR_LOG_LENGTH: usize = 256;
 
 /// Topic, Payload as JSON
@@ -47,7 +44,7 @@ impl Insights {
             panic!("Insights utility needs already-connected Tether Agent");
         }
         let _input_plug = PlugOptionsBuilder::create_input("monitor")
-            .topic(&options.topic)
+            .topic(Some(options.topic.clone()))
             .build(tether_agent)
             .expect("failed to connect Tether");
 

--- a/utilities/tether-utils/src/tether_topics/mod.rs
+++ b/utilities/tether-utils/src/tether_topics/mod.rs
@@ -22,3 +22,27 @@ impl Default for TopicOptions {
         }
     }
 }
+
+pub fn parse_plug_name(topic: &str) -> Option<&str> {
+    let parts: Vec<&str> = topic.split('/').collect();
+    match parts.get(2) {
+        Some(s) => Some(*s),
+        None => None,
+    }
+}
+
+pub fn parse_agent_id(topic: &str) -> Option<&str> {
+    let parts: Vec<&str> = topic.split('/').collect();
+    match parts.get(1) {
+        Some(s) => Some(*s),
+        None => None,
+    }
+}
+
+pub fn parse_agent_role(topic: &str) -> Option<&str> {
+    let parts: Vec<&str> = topic.split('/').collect();
+    match parts.first() {
+        Some(s) => Some(*s),
+        None => None,
+    }
+}


### PR DESCRIPTION
A few things are combined into this Feature Request, including a little bit of reorganising (splitting things into modules) which might make some changes a little more difficult to follow, but the summary is below.

## Main change: Plug Definition "building"
Prior to this version, topics for Input Plug Definitions and Output Plug Definitions were constructed in one of two ways:

1. Automatically (join the Agent Role + ID + Plug Name)
2. Manually (provide your own topic by calling `.topic`)

This was perfectly usable, but assumed that the developer would understand enough about the Tether topic conventions to construct their own topics manually if needed, without any checks being performed.

This proposed new API allows the end-user developer to construct Plug Definitions in a few different ways:
1. Automatically with defaults (only the Plug Name must be provided)
2. Automatically but with one or more **parts** of the topic explicitly provided in addition, i.e. Role and/or ID through functions such as `.id(Some("customID".into())` or `.role(Some("customRole".into))`
3. Completely manually, as before, by providing a string to override the topic using, e.g. `.topic("my/custom/topic".into())`

The advantage of method#2 specifically is that the end-user makes use of the [Three Part Topic](https://github.com/RandomStudio/tether#b-the-three-part-topic) convention more directly, and the system will ensure that proper defaults will be applied for the other parts of the topic, whether for subscribing (e.g. using `+` wildcards in certain positions) or publishing (provide suitable strings such as `any` in certain positions).

## Other breaking changes: Optional values for optional config functions
In order to make things more consistent between `TetherAgentOptionsBuilder` and `PlugOptionsBuilder`, everything that does not **need** to be specified makes use of `Option<T>` parameters. This is useful in cases where configuration is coming from elsewhere (and these are also optional), so you can **either** simply omit the function call **or** specify `None` - the effect will be the same (apply defaults), but depending on the situation this may be more useful.
```
let tether_agent = TetherAgentOptionsBuilder::new("example")
        .id(None) // use default; same as not calling `.id` at all
```
All functions that had variations in v0.9 such as `.id` / `.id_optional` have been replaced with a single function call instead. This will break some code that assumed v0.9 function signatures, but these will be infrequent and easy to update.

## Examples and Tether Utils updated
All examples for the Rust Base Agent have been updated to respect and demonstrate the use of the new API. Reviewing the examples can be helpful to see the effects of the proposed change.

Tether Utils has also been updated to use the new API. This is where the API changes are particularly helpful, making it easy to specify partially customised plug definitions such as:
```
tether receive --plug.id
```