### PR TITLE
Tidy API with fewer Strings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,23 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+    {
+      "name": "Debug Rust Base Agent unit tests",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+          "args": [
+            "test", "--no-run", "--lib",
+            "--manifest-path", "${workspaceFolder}/base_agent/rs/Cargo.toml"
+          ], // Cargo command line to build the debug target
+          // "args": ["build", "--bin=foo"] is another possibility
+          // "filter": { // Filter applied to compilation artifacts (optional)
+          //     "name": "mylib",
+          //     "kind": "lib"
+          // }
+      }
+  },
+
   {
     "type": "lldb",
     "request": "launch",

--- a/base_agent/rs/Cargo.lock
+++ b/base_agent/rs/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/base_agent/rs/Cargo.lock
+++ b/base_agent/rs/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/base_agent/rs/Cargo.toml
+++ b/base_agent/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-agent"
 description = "Standardised use of MQTT and MessagePack for inter-process communication"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/base_agent/rs/Cargo.toml
+++ b/base_agent/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-agent"
 description = "Standardised use of MQTT and MessagePack for inter-process communication"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -15,7 +15,7 @@ fn main() {
     let output_plug = PlugOptionsBuilder::create_output("anOutput")
         .role(Some("pretendingToBeSomethingElse"))
         .qos(Some(2))
-        .retain(true)
+        .retain(Some(true))
         .build(&tether_agent);
     let input_wildcard_plug = PlugOptionsBuilder::create_input("everything")
         .topic(Some("#"))

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -5,25 +5,25 @@ use tether_agent::{
 fn main() {
     let tether_agent = TetherAgentOptionsBuilder::new("example")
         .id(None)
-        .host(Some("localhost".into()))
+        .host(Some("localhost"))
         .port(1883)
-        .username(Some("tether".into()))
-        .password(Some("sp_ceB0ss!".into()))
+        .username(Some("tether"))
+        .password(Some("sp_ceB0ss!"))
         .build()
         .expect("failed to create Tether Agent");
 
     let output_plug = PlugOptionsBuilder::create_output("anOutput")
-        .role(Some("pretendingToBeSomethingElse".into()))
+        .role(Some("pretendingToBeSomethingElse"))
         .qos(2)
         .retain(true)
         .build(&tether_agent);
     let input_wildcard_plug = PlugOptionsBuilder::create_input("everything")
-        .topic(Some("#".into()))
+        .topic(Some("#"))
         .build(&tether_agent);
 
     let input_customid_plug = PlugOptionsBuilder::create_input("someData")
         .role(None) // i.e., just use default
-        .id(Some("specificIDonly".into()))
+        .id(Some("specificIDonly"))
         .build(&tether_agent);
 
     println!("Agent looks like this: {:?}", tether_agent.description());

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -6,7 +6,7 @@ fn main() {
     let tether_agent = TetherAgentOptionsBuilder::new("example")
         .id(None)
         .host(Some("localhost"))
-        .port(1883)
+        .port(Some(1883))
         .username(Some("tether"))
         .password(Some("sp_ceB0ss!"))
         .build()

--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let output_plug = PlugOptionsBuilder::create_output("anOutput")
         .role(Some("pretendingToBeSomethingElse"))
-        .qos(2)
+        .qos(Some(2))
         .retain(true)
         .build(&tether_agent);
     let input_wildcard_plug = PlugOptionsBuilder::create_input("everything")

--- a/base_agent/rs/examples/error_handling.rs
+++ b/base_agent/rs/examples/error_handling.rs
@@ -16,9 +16,9 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let bad_tether_agent = TetherAgentOptionsBuilder::new("tester")
-        .host(Some("tether-io.dev".into()))
-        .username(Some("bla".into()))
-        .password(Some("bla".into()))
+        .host(Some("tether-io.dev"))
+        .username(Some("bla"))
+        .password(Some("bla"))
         .build();
     match bad_tether_agent {
         Ok(_agent) => {
@@ -28,7 +28,7 @@ fn main() {
     }
 
     let disconnected = TetherAgentOptionsBuilder::new("tester")
-        .host(Some("tether-io.dev".into()))
+        .host(Some("tether-io.dev"))
         .auto_connect(false)
         .build()
         .expect("this ought initialise but not conect");
@@ -65,8 +65,7 @@ fn main() {
         .publish(&output, Some(bad_payload))
         .expect("This will produce an error when DECODING, but not checked by library");
 
-    let bad_topic_input =
-        PlugOptionsBuilder::create_input("something").topic(Some("*/#/house+".into()));
+    let bad_topic_input = PlugOptionsBuilder::create_input("something").topic(Some("*/#/house+"));
     match bad_topic_input.build(&working_tether_agent) {
         Ok(_) => panic!("Weird topic: This shouldn't work!"),
         Err(e) => warn!("Got a subscribe error (bad topic) as expected: {e:?}"),

--- a/base_agent/rs/examples/publish.rs
+++ b/base_agent/rs/examples/publish.rs
@@ -36,11 +36,11 @@ fn main() {
         .build(&agent)
         .expect("failed to create output");
     let grouped_output_1 = PlugOptionsBuilder::create_output("one")
-        .id(Some("groupMessages".into()))
+        .id(Some("groupMessages"))
         .build(&agent)
         .expect("failed to create output");
     let grouped_output_2 = PlugOptionsBuilder::create_output("two")
-        .id(Some("groupMessages".into()))
+        .id(Some("groupMessages"))
         .build(&agent)
         .expect("failed to create output");
 

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -26,7 +26,7 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
-        .id(Some("example".into()))
+        .id(Some("example"))
         .build()
         .expect("failed to init Tether agent");
 
@@ -35,7 +35,7 @@ fn main() {
         .expect("failed to create input");
     debug!("input one {} = {}", input_one.name(), input_one.topic());
     let input_two = PlugOptionsBuilder::create_input("two")
-        .role(Some("specific".into()))
+        .role(Some("specific"))
         .build(&tether_agent)
         .expect("failed to create input");
     debug!("input two {} = {}", input_two.name(), input_two.topic());
@@ -44,12 +44,12 @@ fn main() {
         .expect("failed to create input");
 
     let input_everything = PlugOptionsBuilder::create_input("everything")
-        .topic(Some("#".into()))
+        .topic(Some("#"))
         .build(&tether_agent)
         .expect("failed to create input");
 
     let input_specify_id = PlugOptionsBuilder::create_input("groupMessages")
-        .id(Some("someGroup".into()))
+        .id(Some("someGroup"))
         .name(None)
         .build(&tether_agent)
         .expect("failed to create input");

--- a/base_agent/rs/examples/subscribe_publish_threaded.rs
+++ b/base_agent/rs/examples/subscribe_publish_threaded.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let tether_agent = Arc::new(Mutex::new(
         TetherAgentOptionsBuilder::new("RustDemoAgent")
-            .id(Some("example".into()))
+            .id(Some("example"))
             .build()
             .expect("failed to init/connect"),
     ));

--- a/base_agent/rs/examples/subscribe_threaded.rs
+++ b/base_agent/rs/examples/subscribe_threaded.rs
@@ -27,7 +27,7 @@ fn main() {
 
     let tether_agent = Arc::new(Mutex::new(
         TetherAgentOptionsBuilder::new("RustDemoAgent")
-            .id(Some("example".into()))
+            .id(Some("example"))
             .build()
             .expect("failed to init/connect"),
     ));

--- a/base_agent/rs/examples/username_password.rs
+++ b/base_agent/rs/examples/username_password.rs
@@ -20,9 +20,9 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let tether_agent = TetherAgentOptionsBuilder::new("RustDemoAgent")
-        .host(Some("10.112.10.10".into()))
-        .username(Some("connected.space".into()))
-        .password(Some("connected.space".into()))
+        .host(Some("10.112.10.10"))
+        .username(Some("connected.space"))
+        .password(Some("connected.space"))
         .build()
         .expect("Failed to initialise and connect");
     let (role, id, _) = tether_agent.description();

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -51,13 +51,13 @@ impl TetherAgentOptionsBuilder {
     }
 
     /// Provide Some(value) to override or None to use default
-    pub fn id(mut self, id: Option<String>) -> Self {
+    pub fn id(mut self, id: Option<&str>) -> Self {
         self.id = convert_optional(id);
         self
     }
 
     /// Provide Some(value) to override or None to use default
-    pub fn host(mut self, host: Option<String>) -> Self {
+    pub fn host(mut self, host: Option<&str>) -> Self {
         self.host = convert_optional(host);
         self
     }
@@ -68,13 +68,13 @@ impl TetherAgentOptionsBuilder {
     }
 
     /// Provide Some(value) to override or None to use default
-    pub fn username(mut self, username: Option<String>) -> Self {
+    pub fn username(mut self, username: Option<&str>) -> Self {
         self.username = convert_optional(username);
         self
     }
 
     /// Provide Some(value) to override or None to use default
-    pub fn password(mut self, password: Option<String>) -> Self {
+    pub fn password(mut self, password: Option<&str>) -> Self {
         self.password = convert_optional(password);
         self
     }

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -10,12 +10,16 @@ use crate::{
 };
 
 const TIMEOUT_SECONDS: u64 = 10;
+const DEFAULT_USERNAME: &str = "tether";
+const DEFAULT_PASSWORD: &str = "sp_ceB0ss!";
 pub struct TetherAgent {
     role: String,
     id: String,
     client: Client,
     broker_uri: String,
     receiver: Receiver<Option<Message>>,
+    username: String,
+    password: String,
 }
 #[derive(Clone)]
 pub struct TetherAgentOptionsBuilder {
@@ -102,10 +106,12 @@ impl TetherAgentOptionsBuilder {
             client,
             broker_uri,
             receiver,
+            username: self.username.unwrap_or(DEFAULT_USERNAME.into()),
+            password: self.password.unwrap_or(DEFAULT_PASSWORD.into()),
         };
 
         if self.auto_connect {
-            match agent.connect(&self) {
+            match agent.connect() {
                 Ok(()) => Ok(agent),
                 Err(e) => Err(e.into()),
             }
@@ -152,12 +158,10 @@ impl TetherAgent {
         self.id = id.into();
     }
 
-    pub fn connect(&self, options: &TetherAgentOptionsBuilder) -> Result<(), mqtt::Error> {
-        let username = options.clone().username.unwrap_or("tether".into());
-        let password = options.clone().password.unwrap_or("sp_ceB0ss!".into());
+    pub fn connect(&self) -> Result<(), mqtt::Error> {
         let conn_opts = mqtt::ConnectOptionsBuilder::new()
-            .user_name(username)
-            .password(password)
+            .user_name(&self.username)
+            .password(&self.password)
             .connect_timeout(Duration::from_secs(TIMEOUT_SECONDS))
             .keep_alive_interval(Duration::from_secs(TIMEOUT_SECONDS))
             // .mqtt_version(mqtt::MQTT_VERSION_3_1_1)

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -189,6 +189,8 @@ impl TetherAgent {
     }
 
     /// If a message is waiting return ThreePartTopic, Message (String, Message)
+    /// Messages received on topics that are not parseable as Tether Three Part Topics will be returned with
+    /// the complete Topic string instead
     pub fn check_messages(&self) -> Option<(TetherOrCustomTopic, Message)> {
         if let Some(message) = self.receiver.try_iter().find_map(|m| m) {
             if let Ok(t) = ThreePartTopic::try_from(message.topic()) {

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -62,8 +62,8 @@ impl TetherAgentOptionsBuilder {
         self
     }
 
-    pub fn port(mut self, port: u16) -> Self {
-        self.port = Some(port);
+    pub fn port(mut self, port: Option<u16>) -> Self {
+        self.port = convert_optional(port);
         self
     }
 

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -28,13 +28,6 @@ pub struct TetherAgentOptionsBuilder {
     auto_connect: bool,
 }
 
-fn convert_optional<T, U: std::convert::From<T>>(optional_value: Option<T>) -> Option<U> {
-    match optional_value {
-        Some(v) => Some(v.into()),
-        None => None,
-    }
-}
-
 impl TetherAgentOptionsBuilder {
     /// Initialise Tether Options struct with default options; call other methods to customise.
     /// Call `build()` to get the actual TetherAgent instance (and connect automatically, by default)
@@ -52,30 +45,30 @@ impl TetherAgentOptionsBuilder {
 
     /// Provide Some(value) to override or None to use default
     pub fn id(mut self, id: Option<&str>) -> Self {
-        self.id = convert_optional(id);
+        self.id = id.map(|x| x.into());
         self
     }
 
     /// Provide Some(value) to override or None to use default
     pub fn host(mut self, host: Option<&str>) -> Self {
-        self.host = convert_optional(host);
+        self.host = host.map(|x| x.into());
         self
     }
 
     pub fn port(mut self, port: Option<u16>) -> Self {
-        self.port = convert_optional(port);
+        self.port = port;
         self
     }
 
     /// Provide Some(value) to override or None to use default
     pub fn username(mut self, username: Option<&str>) -> Self {
-        self.username = convert_optional(username);
+        self.username = username.map(|x| x.into());
         self
     }
 
     /// Provide Some(value) to override or None to use default
     pub fn password(mut self, password: Option<&str>) -> Self {
-        self.password = convert_optional(password);
+        self.password = password.map(|x| x.into());
         self
     }
 

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -186,13 +186,13 @@ impl PlugOptionsBuilder {
         self
     }
 
-    pub fn retain(mut self, should_retain: bool) -> Self {
+    pub fn retain(mut self, should_retain: Option<bool>) -> Self {
         match &mut self {
             Self::InputPlugOptions(_) => {
                 error!("Cannot set retain flag on Input Plug / subscription");
             }
             Self::OutputPlugOptions(s) => {
-                s.retain = Some(should_retain);
+                s.retain = should_retain;
             }
         }
         self

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -26,8 +26,8 @@ pub struct OutputPlugOptions {
 
 /// This is the definition of an Input or Output Plug.
 ///
-/// You should never use an instance of this directly; call `.build()` at the
-/// end of the chain to get a usable PlugDefinition
+/// You typically don't use an instance of this directly; call `.build()` at the
+/// end of the chain to get a usable **PlugDefinition**
 pub enum PlugOptionsBuilder {
     InputPlugOptions(InputPlugOptions),
     OutputPlugOptions(OutputPlugOptions),

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -77,14 +77,14 @@ impl PlugOptionsBuilder {
                 if s.override_topic.is_some() {
                     error!("Override topic was also provided; this will take precedence");
                 } else {
-                    s.override_subscribe_role = role.and_then(|s| Some(s.into()));
+                    s.override_subscribe_role = role.map(|s| s.into());
                 }
             }
             PlugOptionsBuilder::OutputPlugOptions(s) => {
                 if s.override_topic.is_some() {
                     error!("Override topic was also provided; this will take precedence");
                 } else {
-                    s.override_publish_role = role.and_then(|s| Some(s.into()));
+                    s.override_publish_role = role.map(|s| s.into());
                 }
             }
         };
@@ -105,14 +105,14 @@ impl PlugOptionsBuilder {
                 if s.override_topic.is_some() {
                     error!("Override topic was also provided; this will take precedence");
                 } else {
-                    s.override_subscribe_id = id.and_then(|s| Some(s.into()));
+                    s.override_subscribe_id = id.map(|s| s.into());
                 }
             }
             PlugOptionsBuilder::OutputPlugOptions(s) => {
                 if s.override_topic.is_some() {
                     error!("Override topic was also provided; this will take precedence");
                 } else {
-                    s.override_publish_id = id.and_then(|s| Some(s.into()));
+                    s.override_publish_id = id.map(|s| s.into());
                 }
             }
         };
@@ -134,18 +134,16 @@ impl PlugOptionsBuilder {
             PlugOptionsBuilder::InputPlugOptions(opt) => {
                 if opt.override_topic.is_some() {
                     error!("Override topic was also provided; this will take precedence");
-                } else {
-                    if let Some(s) = override_plug_name {
-                        if s.eq("+") {
-                            info!("This is a wildcard; subscribe topic will use this but Plug Name will remain unchanged");
-                        } else {
-                            error!("Input Plugs cannot change their name after ::create_input constructor EXCEPT for wildcard \"+\"");
-                        }
-                        opt.override_subscribe_plug_name =
-                            override_plug_name.and_then(|s| Some(s.into()));
+                }
+                if let Some(s) = override_plug_name {
+                    if s.eq("+") {
+                        info!("This is a wildcard; subscribe topic will use this but Plug Name will remain unchanged");
                     } else {
-                        debug!("Override plug name set to None; will use original name \"{}\" given in ::create_input constructor", opt.plug_name);
+                        error!("Input Plugs cannot change their name after ::create_input constructor EXCEPT for wildcard \"+\"");
                     }
+                    opt.override_subscribe_plug_name = override_plug_name.map(|s| s.into());
+                } else {
+                    debug!("Override plug name set to None; will use original name \"{}\" given in ::create_input constructor", opt.plug_name);
                 }
             }
             PlugOptionsBuilder::OutputPlugOptions(_) => {
@@ -222,7 +220,7 @@ impl PlugOptionsBuilder {
                     InputPlugDefinition::new(&plug_options.plug_name, tpt, plug_options.qos);
                 match tether_agent
                     .client()
-                    .subscribe(plug_definition.topic().as_str(), plug_definition.qos())
+                    .subscribe(plug_definition.topic(), plug_definition.qos())
                 {
                     Ok(res) => {
                         debug!("This topic was fine: \"{}\"", plug_definition.topic());

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -212,7 +212,7 @@ impl PlugOptionsBuilder {
                             &plug_options.plug_name,
                             plug_options.override_subscribe_role.as_deref(),
                             plug_options.override_subscribe_id.as_deref(),
-                            plug_options.override_subscribe_plug_name,
+                            plug_options.override_subscribe_plug_name.as_deref(),
                         ))
                     }
                 };

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -210,8 +210,8 @@ impl PlugOptionsBuilder {
 
                         TetherOrCustomTopic::Tether(ThreePartTopic::new_for_subscribe(
                             &plug_options.plug_name,
-                            plug_options.override_subscribe_role,
-                            plug_options.override_subscribe_id,
+                            plug_options.override_subscribe_role.as_deref(),
+                            plug_options.override_subscribe_id.as_deref(),
                             plug_options.override_subscribe_plug_name,
                         ))
                     }
@@ -234,8 +234,8 @@ impl PlugOptionsBuilder {
                 let tpt: TetherOrCustomTopic = match plug_options.override_topic {
                     Some(custom) => TetherOrCustomTopic::Custom(custom),
                     None => TetherOrCustomTopic::Tether(ThreePartTopic::new_for_publish(
-                        plug_options.override_publish_role,
-                        plug_options.override_publish_id,
+                        plug_options.override_publish_role.as_deref(),
+                        plug_options.override_publish_id.as_deref(),
                         &plug_options.plug_name,
                         tether_agent,
                     )),

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -160,6 +160,8 @@ impl PlugOptionsBuilder {
     /// produce a warning. It's therefore valid to use a wildcard such as "#", for Input (subscribing).
     ///
     /// Any customisations specified using `.role(...)` or `.id(...)` will be ignored if this function is called.
+    ///
+    /// By default, the override_topic is None, but you can specify None explicitly using this function.
     pub fn topic(mut self, override_topic: Option<&str>) -> Self {
         match override_topic {
             Some(t) => {

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -56,10 +56,10 @@ impl PlugOptionsBuilder {
         })
     }
 
-    pub fn qos(mut self, qos: i32) -> Self {
+    pub fn qos(mut self, qos: Option<i32>) -> Self {
         match &mut self {
-            PlugOptionsBuilder::InputPlugOptions(s) => s.qos = Some(qos),
-            PlugOptionsBuilder::OutputPlugOptions(s) => s.qos = Some(qos),
+            PlugOptionsBuilder::InputPlugOptions(s) => s.qos = qos,
+            PlugOptionsBuilder::OutputPlugOptions(s) => s.qos = qos,
         };
         self
     }

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -220,7 +220,7 @@ impl PlugOptionsBuilder {
                     InputPlugDefinition::new(&plug_options.plug_name, tpt, plug_options.qos);
                 match tether_agent
                     .client()
-                    .subscribe(plug_definition.topic(), plug_definition.qos())
+                    .subscribe(&plug_definition.topic(), plug_definition.qos())
                 {
                     Ok(res) => {
                         debug!("This topic was fine: \"{}\"", plug_definition.topic());

--- a/base_agent/rs/src/plugs/three_part_topic.rs
+++ b/base_agent/rs/src/plugs/three_part_topic.rs
@@ -37,7 +37,7 @@ impl ThreePartTopic {
         plug_name: &str,
         role: Option<&str>,
         id: Option<&str>,
-        plug_name_part_override: Option<String>,
+        plug_name_part_override: Option<&str>,
     ) -> ThreePartTopic {
         let role = role.unwrap_or("+");
         let id = id.unwrap_or("+");
@@ -46,16 +46,16 @@ impl ThreePartTopic {
                 if !&s.eq("+") {
                     error!("The only valid override for the Plug Name part is a wildcard (+)");
                 }
-                s.clone()
+                s
             }
-            None => String::from(plug_name),
+            None => plug_name,
         };
         let full_topic = build_topic(&role, &id, &plug_name_part);
 
         ThreePartTopic {
             role: role.into(),
             id: id.into(),
-            plug_name: plug_name_part,
+            plug_name: plug_name_part.into(),
             full_topic,
         }
     }

--- a/base_agent/rs/src/plugs/three_part_topic.rs
+++ b/base_agent/rs/src/plugs/three_part_topic.rs
@@ -32,7 +32,8 @@ impl ThreePartTopic {
     }
 
     /// Subscribe topics fall back to wildcard `+` for role and/or id if not explicitly provided.
-    /// If `plug_name_part` is specified as `Some(String)` then the part
+    /// If `plug_name_part` is specified as `Some(String)` then the plug name part of the generated
+    /// topic is changed but the plug name itself is left alone.
     pub fn new_for_subscribe(
         plug_name: &str,
         role: Option<&str>,

--- a/base_agent/rs/src/plugs/three_part_topic.rs
+++ b/base_agent/rs/src/plugs/three_part_topic.rs
@@ -15,19 +15,18 @@ pub struct ThreePartTopic {
 impl ThreePartTopic {
     /// Publish topics fall back to the ID and/or role associated with the agent, if not explicitly provided
     pub fn new_for_publish(
-        role: Option<String>,
-        id: Option<String>,
+        role: Option<&str>,
+        id: Option<&str>,
         plug_name: &str,
         agent: &TetherAgent,
     ) -> ThreePartTopic {
-        let role = role.unwrap_or(agent.role().into());
-        let id = id.unwrap_or(agent.id().into());
-        let plug_name = String::from(plug_name);
+        let role = role.unwrap_or(agent.role());
+        let id = id.unwrap_or(agent.id());
         let full_topic = build_topic(&role, &id, &plug_name);
         ThreePartTopic {
-            role,
-            id,
-            plug_name,
+            role: role.into(),
+            id: id.into(),
+            plug_name: plug_name.into(),
             full_topic,
         }
     }
@@ -36,12 +35,12 @@ impl ThreePartTopic {
     /// If `plug_name_part` is specified as `Some(String)` then the part
     pub fn new_for_subscribe(
         plug_name: &str,
-        role: Option<String>,
-        id: Option<String>,
+        role: Option<&str>,
+        id: Option<&str>,
         plug_name_part_override: Option<String>,
     ) -> ThreePartTopic {
-        let role = role.unwrap_or("+".into());
-        let id = id.unwrap_or("+".into());
+        let role = role.unwrap_or("+");
+        let id = id.unwrap_or("+");
         let plug_name_part = match plug_name_part_override {
             Some(s) => {
                 if !&s.eq("+") {
@@ -54,8 +53,8 @@ impl ThreePartTopic {
         let full_topic = build_topic(&role, &id, &plug_name_part);
 
         ThreePartTopic {
-            role,
-            id,
+            role: role.into(),
+            id: id.into(),
             plug_name: plug_name_part,
             full_topic,
         }

--- a/base_agent/rs/src/plugs/three_part_topic.rs
+++ b/base_agent/rs/src/plugs/three_part_topic.rs
@@ -22,7 +22,7 @@ impl ThreePartTopic {
     ) -> ThreePartTopic {
         let role = role.unwrap_or(agent.role());
         let id = id.unwrap_or(agent.id());
-        let full_topic = build_topic(&role, &id, &plug_name);
+        let full_topic = build_topic(role, id, plug_name);
         ThreePartTopic {
             role: role.into(),
             id: id.into(),
@@ -50,7 +50,7 @@ impl ThreePartTopic {
             }
             None => plug_name,
         };
-        let full_topic = build_topic(&role, &id, &plug_name_part);
+        let full_topic = build_topic(role, id, plug_name_part);
 
         ThreePartTopic {
             role: role.into(),
@@ -65,7 +65,7 @@ impl ThreePartTopic {
             role: role.into(),
             id: id.into(),
             plug_name: plug_name.into(),
-            full_topic: build_topic(&role, &id, &plug_name),
+            full_topic: build_topic(role, id, plug_name),
         }
     }
 
@@ -121,11 +121,11 @@ impl TryFrom<&str> for ThreePartTopic {
             debug!("parts: {:?}", parts);
         }
 
-        let role = parts.get(0).expect("the role part should exist");
+        let role = parts.first().expect("the role part should exist");
         let id = parts.get(1).expect("the id part should exist");
         let plug_name = parts.get(2).expect("the plug_name part should exist");
 
-        return Ok(ThreePartTopic::new(role, id, plug_name));
+        Ok(ThreePartTopic::new(role, id, plug_name))
     }
 }
 

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "tether-utils"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "circular-buffer",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -741,9 +741,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ce0794a5d311a8b2bfc3612317461a3245a3dc428f70db190d647bcc8ee735"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -756,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "tether-utils"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "circular-buffer",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-utils"
 description = "Utilities for Tether Systems"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"
@@ -13,8 +13,8 @@ name = "tether"
 
 
 [dependencies]
-# tether-agent = { path = "../../base_agent/rs" }
-tether-agent = "0.10"
+tether-agent = { path = "../../base_agent/rs" }
+# tether-agent = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 rmp-serde = "1.1.1"

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-utils"
 description = "Utilities for Tether Systems"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/utilities/tether-utils/src/bin/tether/main.rs
+++ b/utilities/tether-utils/src/bin/tether/main.rs
@@ -1,8 +1,7 @@
 use crossterm::{
-    cursor::{self, RestorePosition, SavePosition},
+    cursor::{RestorePosition, SavePosition},
     execute,
     style::Print,
-    terminal::{disable_raw_mode, enable_raw_mode},
 };
 use env_logger::{Builder, Env};
 use log::*;
@@ -26,8 +25,8 @@ pub struct Cli {
     #[arg(long = "host", default_value_t=String::from("localhost"))]
     pub tether_host: String,
 
-    #[arg(long = "port", default_value_t = 1883)]
-    pub tether_port: u16,
+    #[arg(long = "port")]
+    pub tether_port: Option<u16>,
 
     #[arg(long = "username", default_value_t=String::from("tether"))]
     pub tether_username: String,
@@ -67,17 +66,17 @@ fn main() {
     debug!("Debugging is enabled; could be verbose");
 
     let tether_agent = TetherAgentOptionsBuilder::new(&cli.tether_role)
-        .id(Some(cli.tether_id.into()))
-        .host(Some(cli.tether_host.clone()))
+        .id(Some(cli.tether_id).as_deref())
+        .host(Some(cli.tether_host.clone()).as_deref())
         .port(cli.tether_port)
-        .username(Some(cli.tether_username.into()))
-        .password(Some(cli.tether_password.into()))
+        .username(Some(cli.tether_username).as_deref())
+        .password(Some(cli.tether_password).as_deref())
         .build()
         .unwrap_or_else(|_| {
             error!("Failed to initialise and/or connect the Tether Agent");
             warn!(
                 "Check your Tether settings and ensure that you have a correctly-configured MQTT broker running at {}:{}",
-                cli.tether_host, cli.tether_port
+                &cli.tether_host, cli.tether_port.unwrap_or(1883)
             );
             panic!("Failed to init/connect Tether Agent")
         });

--- a/utilities/tether-utils/src/tether_receive.rs
+++ b/utilities/tether-utils/src/tether_receive.rs
@@ -38,16 +38,16 @@ pub fn receive(
                 &options.subscribe_id, &options.subscribe_role, &options.subscribe_plug
             );
             PlugOptionsBuilder::create_input("all")
-                .role(options.subscribe_role.clone())
-                .id(options.subscribe_id.clone())
-                .name(options.subscribe_plug.clone().and_then(|s| Some(s)))
+                .role(options.subscribe_role.as_deref())
+                .id(options.subscribe_id.as_deref())
+                .name(options.subscribe_plug.as_deref())
         } else {
             debug!(
                 "Using custom override topic \"{:?}\"",
                 &options.subscribe_topic
             );
             PlugOptionsBuilder::create_input("all")
-                .topic(Some(options.subscribe_topic.clone().unwrap_or("#".into())))
+                .topic(Some(options.subscribe_topic.as_deref().unwrap_or("#")))
         }
     };
 

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -96,7 +96,7 @@ impl TetherRecordUtil {
         info!("Tether Record Utility: start recording");
 
         let _input = PlugOptionsBuilder::create_input("all")
-            .topic(Some(self.options.topic.clone())) // TODO: should be possible to build TPT
+            .topic(Some(self.options.topic.clone()).as_deref()) // TODO: should be possible to build TPT
             .build(tether_agent)
             .expect("failed to create input plug");
 

--- a/utilities/tether-utils/src/tether_record.rs
+++ b/utilities/tether-utils/src/tether_record.rs
@@ -103,18 +103,25 @@ impl TetherRecordUtil {
         let file_path = match &self.options.file_override_path {
             Some(override_path) => String::from(override_path),
             None => {
-                let timestamp = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or(Duration::from_secs(0))
-                    .as_secs();
-                format!(
-                    "{}{}-{}.json",
-                    self.options.file_base_path, self.options.file_base_name, timestamp
-                )
+                if self.options.file_no_timestamp {
+                    format!(
+                        "{}{}.json",
+                        self.options.file_base_path, self.options.file_base_name
+                    )
+                } else {
+                    let timestamp = SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)
+                        .unwrap_or(Duration::from_secs(0))
+                        .as_secs();
+                    format!(
+                        "{}{}-{}.json",
+                        self.options.file_base_path, self.options.file_base_name, timestamp
+                    )
+                }
             }
         };
 
-        info!("Writing recorded data to {} ...", &file_path);
+        info!("Writing recorded data to \"{}\" ...", &file_path);
 
         let file = File::create(&file_path).expect("failed to create file");
         let mut file = LineWriter::new(file);

--- a/utilities/tether-utils/src/tether_send.rs
+++ b/utilities/tether-utils/src/tether_send.rs
@@ -47,9 +47,9 @@ pub fn send(options: &SendOptions, tether_agent: &TetherAgent) -> anyhow::Result
     let plug_name = options.plug_name.clone().unwrap_or("testMessages".into());
 
     let output = PlugOptionsBuilder::create_output(&plug_name)
-        .role(options.plug_role.clone())
-        .id(options.plug_id.clone())
-        .topic(options.plug_topic.clone())
+        .role(options.plug_role.as_deref())
+        .id(options.plug_id.as_deref())
+        .topic(options.plug_topic.as_deref())
         .build(tether_agent)
         .expect("failed to create output plug");
 

--- a/utilities/tether-utils/src/tether_topics/insights.rs
+++ b/utilities/tether-utils/src/tether_topics/insights.rs
@@ -44,7 +44,7 @@ impl Insights {
             panic!("Insights utility needs already-connected Tether Agent");
         }
         let _input_plug = PlugOptionsBuilder::create_input("monitor")
-            .topic(Some(options.topic.clone()))
+            .topic(Some(options.topic.clone()).as_deref())
             .build(tether_agent)
             .expect("failed to connect Tether");
 


### PR DESCRIPTION
There are quite a few changes here (again) so I will summarise. Again these are all Rust-related.

# Major changes
## String slices used for function params wherever possible
This was the initial motivation to make some updates. In order to avoid complicated ownership issues, I had previously used `Option<String>` a lot, but then I discovered the magic of `.as_deref()` (see [docs](https://doc.rust-lang.org/std/option/enum.Option.html#method.as_deref)) and it was again possible to use `Option<&str>` in most places. 

This simplifies the API (less need to call `"someString".into()` all over the place) and also avoids unnecessary new allocations.

## Additional optional values
Some values (e.g. QOS for Plugs, Port for Agent) had been accidentally overlooked when making the move to v0.10. All options that can be "left as default" or "set to something custom" now except `Option<T>` as they should, e.g. for `TetherAgentOptionsBuilder` ...
```
port(mut self, port: u16)
```
is now
```
port(mut self, port: Option<u16>)
```
... as it should be.

# Minor changes
- Added Debugging configuration for VSCode for the Unit Tests in the Base Agent
- Implemented plenty of Cargo clippy recommendations including removing unnecessary de-rerefences, `.map` for cleaner option unwrapping, unnecessary lifetime annotations
- Some function descriptions (comments for docs) and log messages improved
- Tether Utils was adapted for the new API, which mostly involved using `as_deref` for some options rather than `.clone()` for strings