### PR TITLE
Feature/update js

### DIFF
--- a/base_agent/js/jest.config.js
+++ b/base_agent/js/jest.config.js
@@ -1,11 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  roots: ["<rootDir>/src"],
-  testMatch: [
-    "**/__tests__/**/*.+(ts|tsx|js)",
-    "**/?(*.)+(spec|test).+(ts|tsx|js)",
-  ],
-  transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest",
-  },
-  verbose: true,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
 };

--- a/base_agent/js/package-lock.json
+++ b/base_agent/js/package-lock.json
@@ -12,6 +12,7 @@
         "@msgpack/msgpack": "^3.0.0-beta2",
         "async-mqtt": "^2.6.2",
         "buffer": "^6.0.3",
+        "events": "^3.3.0",
         "loglevel": "^1.8.0"
       },
       "devDependencies": {
@@ -1804,6 +1805,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {
@@ -5788,6 +5797,11 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "execa": {
       "version": "5.1.1",

--- a/base_agent/js/package-lock.json
+++ b/base_agent/js/package-lock.json
@@ -16,6 +16,10 @@
         "loglevel": "^1.8.0"
       },
       "devDependencies": {
+        "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/recommended": "^1.0.3",
+        "@tsconfig/vite-react": "^2.0.1",
         "@types/jest": "^28.1.6",
         "@types/node": "^15.0.3",
         "@types/uuid": "^8.3.4",
@@ -23,7 +27,7 @@
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^4.5.5"
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -971,6 +975,30 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
+      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/recommended": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
+      "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/vite-react": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/vite-react/-/vite-react-2.0.1.tgz",
+      "integrity": "sha512-Sxt6vfbhgEzV2TH/02wLEiM7RJVYGx1mn2INlzovXS6/Fnm7G+CyOHZUD5c5fOlQvH54LNhdGgfI/9fuK6+kuQ==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -4189,16 +4217,16 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unc-path-regex": {
@@ -5137,6 +5165,30 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@tsconfig/node18": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
+      "dev": true
+    },
+    "@tsconfig/node20": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
+      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==",
+      "dev": true
+    },
+    "@tsconfig/recommended": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
+      "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
+      "dev": true
+    },
+    "@tsconfig/vite-react": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/vite-react/-/vite-react-2.0.1.tgz",
+      "integrity": "sha512-Sxt6vfbhgEzV2TH/02wLEiM7RJVYGx1mn2INlzovXS6/Fnm7G+CyOHZUD5c5fOlQvH54LNhdGgfI/9fuK6+kuQ==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -7598,9 +7650,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "unc-path-regex": {

--- a/base_agent/js/package-lock.json
+++ b/base_agent/js/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "tether-agent",
-  "version": "2.7.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tether-agent",
-      "version": "2.7.2",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
+        "@msgpack/msgpack": "^3.0.0-beta2",
         "async-mqtt": "^2.6.2",
         "buffer": "^6.0.3",
         "loglevel": "^1.8.0"
@@ -936,6 +937,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.0.0-beta2.tgz",
+      "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5090,6 +5099,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@msgpack/msgpack": {
+      "version": "3.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.0.0-beta2.tgz",
+      "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw=="
     },
     "@sinclair/typebox": {
       "version": "0.24.26",

--- a/base_agent/js/package-lock.json
+++ b/base_agent/js/package-lock.json
@@ -1,18 +1,17 @@
 {
-  "name": "@tether/tether-agent",
-  "version": "2.6.0",
+  "name": "tether-agent",
+  "version": "2.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tether/tether-agent",
-      "version": "2.6.0",
+      "name": "tether-agent",
+      "version": "2.7.2",
       "license": "ISC",
       "dependencies": {
         "async-mqtt": "^2.6.2",
         "buffer": "^6.0.3",
-        "loglevel": "^1.8.0",
-        "uuid": "^8.3.2"
+        "loglevel": "^1.8.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -4232,14 +4231,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -7612,11 +7603,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-agent",
-  "version": "2.7.2",
+  "version": "3.0.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "repository": "https://github.com/RandomStudio/tether",
   "dependencies": {
+    "@msgpack/msgpack": "^3.0.0-beta2",
     "async-mqtt": "^2.6.2",
     "buffer": "^6.0.3",
     "loglevel": "^1.8.0"

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "async-mqtt": "^2.6.2",
     "buffer": "^6.0.3",
-    "loglevel": "^1.8.0",
-    "uuid": "^8.3.2"
+    "loglevel": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -15,6 +15,7 @@
     "@msgpack/msgpack": "^3.0.0-beta2",
     "async-mqtt": "^2.6.2",
     "buffer": "^6.0.3",
+    "events": "^3.3.0",
     "loglevel": "^1.8.0"
   },
   "devDependencies": {

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -19,6 +19,10 @@
     "loglevel": "^1.8.0"
   },
   "devDependencies": {
+    "@tsconfig/node18": "^18.2.2",
+    "@tsconfig/node20": "^20.1.2",
+    "@tsconfig/recommended": "^1.0.3",
+    "@tsconfig/vite-react": "^2.0.1",
     "@types/jest": "^28.1.6",
     "@types/node": "^15.0.3",
     "@types/uuid": "^8.3.4",
@@ -26,6 +30,6 @@
     "ts-jest": "^28.0.7",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^4.5.5"
+    "typescript": "^5.2.2"
   }
 }

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -35,19 +35,21 @@ export class InputPlug extends Plug {
   constructor(
     agent: TetherAgent,
     name: string,
-    overrideTopic?: string,
-    subscribeOptions?: IClientSubscribeOptions
+    options?: {
+      overrideTopic?: string;
+      subscribeOptions?: IClientSubscribeOptions;
+    }
   ) {
     super(agent, {
       name,
-      topic: overrideTopic || `+/+/${name}`,
+      topic: options?.overrideTopic || `+/+/${name}`,
     });
     if (!agent.getIsConnected()) {
       throw Error("trying to create an Input before client is connected");
     }
 
     // setTimeout(() => {
-    this.subscribe(subscribeOptions)
+    this.subscribe(options?.subscribeOptions || { qos: 1 })
       .then(() => {
         logger.info("subscribed OK to", this.definition.topic);
       })
@@ -87,16 +89,18 @@ export class OutputPlug extends Plug {
   constructor(
     agent: TetherAgent,
     name: string,
-    overrideTopic?: string,
-    publishOptions?: IClientPublishOptions
+    options?: {
+      overrideTopic?: string;
+      publishOptions?: IClientPublishOptions;
+    }
   ) {
     super(agent, {
       name,
       topic:
-        overrideTopic ||
+        options?.overrideTopic ||
         `${agent.getConfig().role}/${agent.getConfig().id}/${name}`,
     });
-    this.publishOptions = publishOptions || {
+    this.publishOptions = options?.publishOptions || {
       retain: false,
       qos: 1,
     };

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -13,9 +13,6 @@ class Plug extends EventEmitter {
     this.agent = agent;
 
     logger.debug("Plug super definition:", JSON.stringify(definition));
-    if (this instanceof EventEmitter) {
-      logger.debug("Plug is EventEmitter!");
-    }
     this.definition = definition;
   }
 

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -31,7 +31,7 @@ type MessageCallbackListIterm = {
   cb: MessageCallback;
   once: boolean;
 };
-export class Input extends Plug {
+export class InputPlug extends Plug {
   constructor(
     agent: TetherAgent,
     name: string,
@@ -96,7 +96,7 @@ export class Input extends Plug {
   // };
 }
 
-export class Output extends Plug {
+export class OutputPlug extends Plug {
   constructor(agent: TetherAgent, name: string, overrideTopic?: string) {
     super(agent, {
       name,

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -57,11 +57,6 @@ export class InputPlug extends Plug {
   }
 
   subscribe = async (options?: IClientSubscribeOptions) => {
-    if (!this.agent.getIsConnected()) {
-      logger.warn(
-        "subscribing to topic before client is connected; this is allowed but you won't receive any messages until connected"
-      );
-    }
     try {
       logger.debug(
         "Attempting subscribtion to topic",

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -1,14 +1,25 @@
-import { AsyncMqttClient, IClientPublishOptions, IClientSubscribeOptions } from "async-mqtt";
-import { logger } from ".";
+import {
+  AsyncMqttClient,
+  IClientPublishOptions,
+  IClientSubscribeOptions,
+} from "async-mqtt";
+import { TetherAgent, logger } from ".";
 import { MessageCallback, PlugDefinition } from "./types";
 import { Buffer } from "buffer";
+import EventEmitter from "events";
 
-class Plug {
+class Plug extends EventEmitter {
   protected definition: PlugDefinition;
-  protected client: AsyncMqttClient | null;
+  protected agent: TetherAgent;
 
-  constructor(client: AsyncMqttClient, definition: PlugDefinition) {
-    this.client = client;
+  constructor(agent: TetherAgent, definition: PlugDefinition) {
+    super();
+    this.agent = agent;
+
+    if (definition.name === undefined) {
+      throw Error("No name provided for input");
+    }
+
     this.definition = definition;
   }
 
@@ -20,23 +31,32 @@ type MessageCallbackListIterm = {
   once: boolean;
 };
 export class Input extends Plug {
-  private onMessageCallbacksList: MessageCallbackListIterm[];
+  constructor(
+    agent: TetherAgent,
+    name: string,
+    overrideTopic?: string,
+    options?: IClientSubscribeOptions
+  ) {
+    super(agent, {
+      name,
+      topic: overrideTopic || `+/+/${name}`,
+    });
+    if (!agent.getIsConnected()) {
+      throw Error("trying to create an Input before client is connected");
+    }
 
-  constructor(client: AsyncMqttClient, definition: PlugDefinition) {
-    super(client, definition);
-    this.onMessageCallbacksList = [];
-  }
-
-  public onMessage(cb: MessageCallback) {
-    this.onMessageCallbacksList.push({ cb, once: false });
-  }
-
-  public onMessageOnce(cb: MessageCallback) {
-    this.onMessageCallbacksList.push({ cb, once: true });
+    // setTimeout(() => {
+    this.subscribe(options)
+      .then(() => {
+        logger.info("subscribed OK to", this.definition.topic);
+      })
+      .catch((e) => {
+        logger.error("failed to subscribe:", e);
+      });
   }
 
   subscribe = async (options?: IClientSubscribeOptions) => {
-    if (this.client === null) {
+    if (!this.agent.getIsConnected()) {
       logger.warn(
         "subscribing to topic before client is connected; this is allowed but you won't receive any messages until connected"
       );
@@ -47,7 +67,7 @@ export class Input extends Plug {
         this.definition.topic,
         `for Input Plug "${this.getDefinition().name}"...`
       );
-      await this.client.subscribe(this.definition.topic, options);
+      await this.agent.getClient().subscribe(this.definition.topic, options);
     } catch (e) {
       logger.error("Error subscribing ", e);
       throw Error("Subscribe error: " + e);
@@ -57,33 +77,61 @@ export class Input extends Plug {
       this.definition.topic,
       `for Input Plug "${this.getDefinition().name}"`
     );
+    this.agent.getClient().on("message", (topic, payload) => {
+      if (topicMatchesPlug(this.definition.topic, topic)) {
+        this.emit("message", payload, topic);
+      }
+    });
   };
 
-  emitMessage = (payload: Buffer, topic: string) => {
-    this.onMessageCallbacksList.forEach((i) => {
-      i.cb.call(this, payload, topic);
-    });
-    // And delete any "once only" callbacks
-    this.onMessageCallbacksList = this.onMessageCallbacksList.filter(
-      (i) => i.once === false
-    );
-  };
+  // emitMessage = (payload: Buffer, topic: string) => {
+  //   this.onMessageCallbacksList.forEach((i) => {
+  //     i.cb.call(this, payload, topic);
+  //   });
+  //   // And delete any "once only" callbacks
+  //   this.onMessageCallbacksList = this.onMessageCallbacksList.filter(
+  //     (i) => i.once === false
+  //   );
+  // };
 }
 
 export class Output extends Plug {
-  publish = async (content?: Buffer | Uint8Array, options?: IClientPublishOptions) => {
-    if (this.client === null) {
+  constructor(agent: TetherAgent, name: string, overrideTopic?: string) {
+    super(agent, {
+      name,
+      topic: overrideTopic || `${agent.getRole}/${agent.getID()}/${name}`,
+    });
+    if (name === undefined) {
+      throw Error("No name provided for output");
+    }
+    if (!agent.getIsConnected()) {
+      throw Error("trying to create an Output before client is connected");
+    }
+  }
+
+  publish = async (
+    content?: Buffer | Uint8Array,
+    options?: IClientPublishOptions
+  ) => {
+    if (!this.agent.getIsConnected()) {
       logger.error(
         "trying to send without connection; not possible until connected"
       );
     } else {
       try {
+        logger.debug("Sending")
         if (content === undefined) {
-          this.client.publish(this.definition.topic, Buffer.from([]), options);
+          this.agent
+            .getClient()
+            .publish(this.definition.topic, Buffer.from([]), options);
         } else if (content instanceof Uint8Array) {
-          this.client.publish(this.definition.topic, Buffer.from(content), options);
+          this.agent
+            .getClient()
+            .publish(this.definition.topic, Buffer.from(content), options);
         } else {
-          this.client.publish(this.definition.topic, content, options);
+          this.agent
+            .getClient()
+            .publish(this.definition.topic, content, options);
         }
       } catch (e) {
         logger.error("Error publishing message:", e);
@@ -91,3 +139,123 @@ export class Output extends Plug {
     }
   };
 }
+
+/**
+ * Define a named Output to indicate some data that this agent is expected to produce/send.
+ *
+ * For convenience, the topic is generated once and used for every message on this Output instance when calling its `publish` function.
+ */
+// export const createOutput = (
+//   agent: TetherAgent,
+//   name: string,
+//   overrideTopic?: string
+// ) => {
+//   if (name === undefined) {
+//     throw Error("No name provided for output");
+//   }
+//   if (!agent.getIsConnected()) {
+//     throw Error("trying to create an Output before client is connected");
+//   }
+//   const definition: PlugDefinition = {
+//     name,
+//     topic: overrideTopic || `${agent.getRole}/${agent.getID()}/${name}`,
+//   };
+
+//   const output = new Output(agent, definition);
+
+//   return output;
+// };
+
+/**
+ * Define a named Input to indicate some data this agent is expected to consume/receive.
+ *
+ * For convenience, the topic is assumed to end in the given `name`, e.g. an Input named "someTopic" will match messages on topics `foo/bar/someTopic` as well as `something/else/someTopic`.
+ */
+// export const createInput = (
+//   agent: TetherAgent,
+//   name: string,
+//   overrideTopic?: string,
+//   options?: IClientSubscribeOptions
+// ) => {
+//   if (name === undefined) {
+//     throw Error("No name provided for input");
+//   }
+//   if (!agent.getIsConnected()) {
+//     throw Error("trying to create an Input before client is connected");
+//   }
+
+//   // Create a new Input
+//   const definition: PlugDefinition = {
+//     name,
+//     topic: overrideTopic || `+/+/${name}`,
+//   };
+//   const input = new Input(this, definition);
+
+//   // setTimeout(() => {
+//   input
+//     .subscribe(options)
+//     .then(() => {
+//       logger.info("subscribed OK to", definition.topic);
+//     })
+//     .catch((e) => {
+//       logger.error("failed to subscribe:", e);
+//     });
+//   // }, 0);
+//   return input;
+// };
+
+export const topicMatchesPlug = (
+  plugTopic: string,
+  incomingTopic: string
+): boolean => {
+  if (!containsWildcards(plugTopic)) {
+    // No wildcards at all in full topic e.g. specified/alsoSpecified/plugName ...
+    return plugTopic === incomingTopic;
+    // ... Then MATCH only if the defined topic and incoming topic match EXACTLY
+  }
+
+  const incomingPlugName = parsePlugName(incomingTopic);
+  const topicDefinedPlugName = parsePlugName(plugTopic);
+
+  if (!containsWildcards(incomingPlugName)) {
+    if (
+      containsWildcards(parseAgentType(plugTopic)) &&
+      containsWildcards(parseAgentIdOrGroup(plugTopic))
+      // if ONLY the Plug Name was specified (which is the default), then MATCH
+      // anything that matches the Plug Name, regardless of the rest
+    ) {
+      return topicDefinedPlugName === incomingPlugName;
+    }
+
+    // If either the AgentType or ID/Group was specified, check these as well...
+
+    // if AgentType specified, see if this matches, otherwise pass all AgentTypes as matches
+    // e.g. specified/+/plugName
+    const agentTypeMatches = !containsWildcards(parseAgentType(plugTopic))
+      ? parseAgentType(plugTopic) === parseAgentType(incomingTopic)
+      : true;
+
+    // if Agent ID or Group specified, see if this matches, otherwise pass all AgentIdOrGroup as matches
+    // e.g. +/specified/plugName
+    const agentIdOrGroupMatches = !containsWildcards(
+      parseAgentIdOrGroup(plugTopic)
+    )
+      ? parseAgentIdOrGroup(plugTopic) === parseAgentIdOrGroup(incomingTopic)
+      : true;
+
+    return (
+      agentTypeMatches &&
+      agentIdOrGroupMatches &&
+      incomingPlugName === topicDefinedPlugName
+    );
+  } else {
+    // something/something/+ is not allowed for Plugs
+    throw Error("No PlugName was specified for this Plug: " + plugTopic);
+  }
+};
+
+const containsWildcards = (topicOrPart: string) => topicOrPart.includes("+");
+
+export const parsePlugName = (topic: string) => topic.split(`/`)[2];
+export const parseAgentIdOrGroup = (topic: string) => topic.split(`/`)[1];
+export const parseAgentType = (topic: string) => topic.split(`/`)[0];

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -58,13 +58,20 @@ export class InputPlug extends Plug {
   }
 
   private subscribe = async (options?: IClientSubscribeOptions) => {
+    if (this.agent.getClient() === null) {
+      throw Error("agent client not connected");
+    }
     try {
       logger.debug(
         "Attempting subscribtion to topic",
         this.definition.topic,
         `for Input Plug "${this.getDefinition().name}"...`
       );
-      await this.agent.getClient().subscribe(this.definition.topic, options);
+      if (options === undefined) {
+        await this.agent.getClient()?.subscribe(this.definition.topic);
+      } else {
+        await this.agent.getClient()?.subscribe(this.definition.topic, options);
+      }
     } catch (e) {
       logger.error("Error subscribing ", e);
       throw Error("Subscribe error: " + e);
@@ -74,7 +81,7 @@ export class InputPlug extends Plug {
       this.definition.topic,
       `for Input Plug "${this.getDefinition().name}"`
     );
-    this.agent.getClient().on("message", (topic, payload) => {
+    this.agent.getClient()?.on("message", (topic, payload) => {
       if (topicMatchesPlug(this.definition.topic, topic)) {
         this.emit("message", payload, topic);
       }
@@ -127,7 +134,7 @@ export class OutputPlug extends Plug {
         if (content === undefined) {
           this.agent
             .getClient()
-            .publish(
+            ?.publish(
               this.definition.topic,
               Buffer.from([]),
               this.publishOptions
@@ -135,7 +142,7 @@ export class OutputPlug extends Plug {
         } else if (content instanceof Uint8Array) {
           this.agent
             .getClient()
-            .publish(
+            ?.publish(
               this.definition.topic,
               Buffer.from(content),
               this.publishOptions
@@ -143,7 +150,7 @@ export class OutputPlug extends Plug {
         } else {
           this.agent
             .getClient()
-            .publish(this.definition.topic, content, this.publishOptions);
+            ?.publish(this.definition.topic, content, this.publishOptions);
         }
       } catch (e) {
         logger.error("Error publishing message:", e);

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -163,6 +163,10 @@ export const topicMatchesPlug = (
   plugTopic: string,
   incomingTopic: string
 ): boolean => {
+  if (plugTopic == "#") {
+    return true;
+  }
+
   if (!containsWildcards(plugTopic)) {
     // No wildcards at all in full topic e.g. specified/alsoSpecified/plugName ...
     return plugTopic === incomingTopic;

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -100,7 +100,9 @@ export class Output extends Plug {
   constructor(agent: TetherAgent, name: string, overrideTopic?: string) {
     super(agent, {
       name,
-      topic: overrideTopic || `${agent.getRole()}/${agent.getID()}/${name}`,
+      topic:
+        overrideTopic ||
+        `${agent.getConfig().role}/${agent.getConfig().id}/${name}`,
     });
     if (name === undefined) {
       throw Error("No name provided for output");
@@ -140,70 +142,6 @@ export class Output extends Plug {
     }
   };
 }
-
-/**
- * Define a named Output to indicate some data that this agent is expected to produce/send.
- *
- * For convenience, the topic is generated once and used for every message on this Output instance when calling its `publish` function.
- */
-// export const createOutput = (
-//   agent: TetherAgent,
-//   name: string,
-//   overrideTopic?: string
-// ) => {
-//   if (name === undefined) {
-//     throw Error("No name provided for output");
-//   }
-//   if (!agent.getIsConnected()) {
-//     throw Error("trying to create an Output before client is connected");
-//   }
-//   const definition: PlugDefinition = {
-//     name,
-//     topic: overrideTopic || `${agent.getRole}/${agent.getID()}/${name}`,
-//   };
-
-//   const output = new Output(agent, definition);
-
-//   return output;
-// };
-
-/**
- * Define a named Input to indicate some data this agent is expected to consume/receive.
- *
- * For convenience, the topic is assumed to end in the given `name`, e.g. an Input named "someTopic" will match messages on topics `foo/bar/someTopic` as well as `something/else/someTopic`.
- */
-// export const createInput = (
-//   agent: TetherAgent,
-//   name: string,
-//   overrideTopic?: string,
-//   options?: IClientSubscribeOptions
-// ) => {
-//   if (name === undefined) {
-//     throw Error("No name provided for input");
-//   }
-//   if (!agent.getIsConnected()) {
-//     throw Error("trying to create an Input before client is connected");
-//   }
-
-//   // Create a new Input
-//   const definition: PlugDefinition = {
-//     name,
-//     topic: overrideTopic || `+/+/${name}`,
-//   };
-//   const input = new Input(this, definition);
-
-//   // setTimeout(() => {
-//   input
-//     .subscribe(options)
-//     .then(() => {
-//       logger.info("subscribed OK to", definition.topic);
-//     })
-//     .catch((e) => {
-//       logger.error("failed to subscribe:", e);
-//     });
-//   // }, 0);
-//   return input;
-// };
 
 export const topicMatchesPlug = (
   plugTopic: string,

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -20,6 +20,7 @@ class Plug extends EventEmitter {
       throw Error("No name provided for input");
     }
 
+    logger.debug("Plug super definition:", JSON.stringify(definition));
     this.definition = definition;
   }
 
@@ -99,7 +100,7 @@ export class Output extends Plug {
   constructor(agent: TetherAgent, name: string, overrideTopic?: string) {
     super(agent, {
       name,
-      topic: overrideTopic || `${agent.getRole}/${agent.getID()}/${name}`,
+      topic: overrideTopic || `${agent.getRole()}/${agent.getID()}/${name}`,
     });
     if (name === undefined) {
       throw Error("No name provided for output");
@@ -119,7 +120,7 @@ export class Output extends Plug {
       );
     } else {
       try {
-        logger.debug("Sending")
+        logger.debug("Sending on topic", this.definition.topic);
         if (content === undefined) {
           this.agent
             .getClient()

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -48,7 +48,6 @@ export class InputPlug extends Plug {
       throw Error("trying to create an Input before client is connected");
     }
 
-    // setTimeout(() => {
     this.subscribe(options?.subscribeOptions || { qos: 1 })
       .then(() => {
         logger.info("subscribed OK to", this.definition.topic);
@@ -58,7 +57,7 @@ export class InputPlug extends Plug {
       });
   }
 
-  subscribe = async (options?: IClientSubscribeOptions) => {
+  private subscribe = async (options?: IClientSubscribeOptions) => {
     try {
       logger.debug(
         "Attempting subscribtion to topic",

--- a/base_agent/js/src/defaults.ts
+++ b/base_agent/js/src/defaults.ts
@@ -1,22 +1,34 @@
-import { Config } from "./types";
+import { IClientOptions } from "async-mqtt";
+import { TetherConfig } from "./types";
 
-const defaults: Config = {
-  nodeJS: {
-    protocol: "tcp",
-    host: "localhost",
-    port: 1883,
-    path: "",
-    username: "tether",
-    password: "sp_ceB0ss!",
-  },
-  browser: {
-    protocol: "ws",
-    host: "localhost",
-    port: 15675,
-    path: "/ws",
-    username: "tether",
-    password: "sp_ceB0ss!",
-  },
+const NODEJS: IClientOptions = {
+  protocol: "tcp",
+  host: "localhost",
+  port: 1883,
+  path: "",
+  username: "tether",
+  password: "sp_ceB0ss!",
+};
+
+const BROWSER: IClientOptions = {
+  protocol: "ws",
+  host: "localhost",
+  port: 15675,
+  path: "/ws",
+  username: "tether",
+  password: "sp_ceB0ss!",
+};
+
+export const BROKER_DEFAULTS = {
+  nodeJS: NODEJS,
+  browser: BROWSER,
+};
+
+const defaults: TetherConfig = {
+  role: "unknown",
+  id: "any",
+  brokerOptions: NODEJS,
+  autoConnect: true,
 };
 
 export default defaults;

--- a/base_agent/js/src/defaults.ts
+++ b/base_agent/js/src/defaults.ts
@@ -1,11 +1,19 @@
 import { Config } from "./types";
 
 const defaults: Config = {
-  broker: {
+  nodeJS: {
     protocol: "tcp",
-    host: "tether-io.dev",
+    host: "localhost",
     port: 1883,
     path: "",
+    username: "tether",
+    password: "sp_ceB0ss!",
+  },
+  browser: {
+    protocol: "ws",
+    host: "localhost",
+    port: 15675,
+    path: "/ws",
     username: "tether",
     password: "sp_ceB0ss!",
   },

--- a/base_agent/js/src/index.test.ts
+++ b/base_agent/js/src/index.test.ts
@@ -44,6 +44,13 @@ describe("matching topics to plugs", () => {
     ).toBeFalsy();
   });
 
+  test("# wildcard should match any topic", () => {
+    const plugDefinedTopic = "#";
+    expect(
+      topicMatchesPlug(plugDefinedTopic, "something/something/something")
+    ).toBeTruthy();
+  });
+
   test("specific use case: agentType specified, no group/ID, plug name", () => {
     const plugDefinedTopic = "LidarConsolidation/+/trackedPoints";
 

--- a/base_agent/js/src/index.test.ts
+++ b/base_agent/js/src/index.test.ts
@@ -1,4 +1,4 @@
-import { topicMatchesPlug } from ".";
+import { topicMatchesPlug } from "./Plug";
 
 describe("matching topics to plugs", () => {
   test("if Plug specified full topic, i.e. no wildcards, then only exact matches", () => {

--- a/base_agent/js/src/index.ts
+++ b/base_agent/js/src/index.ts
@@ -1,10 +1,6 @@
-import mqtt, {
-  AsyncMqttClient,
-  IClientOptions,
-  IClientSubscribeOptions,
-} from "async-mqtt";
+import mqtt, { AsyncMqttClient, IClientOptions } from "async-mqtt";
 import defaults, { BROKER_DEFAULTS } from "./defaults";
-import { Input, Output } from "./Plug";
+import { InputPlug, OutputPlug } from "./Plug";
 import logger from "loglevel";
 import { LogLevelDesc } from "loglevel";
 import { TetherConfig, TetherOptions } from "./types";
@@ -12,7 +8,7 @@ import { TetherConfig, TetherOptions } from "./types";
 logger.setLevel("info");
 export { logger, BROKER_DEFAULTS };
 
-export { Input, Output, IClientOptions };
+export { InputPlug, OutputPlug, IClientOptions };
 
 export class TetherAgent {
   private config: TetherConfig;

--- a/base_agent/js/src/index.ts
+++ b/base_agent/js/src/index.ts
@@ -10,7 +10,7 @@ import { LogLevelDesc } from "loglevel";
 import { TetherConfig, TetherOptions } from "./types";
 
 logger.setLevel("info");
-export { logger, BROKER_DEFAULTS as DEFAULTS };
+export { logger, BROKER_DEFAULTS };
 
 export { Input, Output, IClientOptions };
 
@@ -28,16 +28,19 @@ export class TetherAgent {
    * @param loglevel Make the Tether library more verbose by setting "debug", for example.
    * @returns
    */
-  public static async create(options: TetherOptions): Promise<TetherAgent> {
+  public static async create(
+    role: string,
+    options?: TetherOptions
+  ): Promise<TetherAgent> {
     const config: TetherConfig = {
-      role: options.role || defaults.role,
-      id: options.id || defaults.id,
-      brokerOptions: options.brokerOptions || defaults.brokerOptions,
-      autoConnect: options.autoConnect || defaults.autoConnect,
+      role,
+      id: options?.id || defaults.id,
+      brokerOptions: options?.brokerOptions || defaults.brokerOptions,
+      autoConnect: options?.autoConnect || defaults.autoConnect,
     };
     const agent = new TetherAgent(
       config,
-      (options.loglevel || "info") as LogLevelDesc
+      (options?.loglevel || "info") as LogLevelDesc
     );
     if (config.autoConnect === true) {
       await agent.connect();

--- a/base_agent/js/src/index.ts
+++ b/base_agent/js/src/index.ts
@@ -9,7 +9,7 @@ import { encode, decode } from "@msgpack/msgpack";
 logger.setLevel("info");
 export { logger, BROKER_DEFAULTS, encode, decode };
 
-export { InputPlug, OutputPlug };
+export { InputPlug, OutputPlug, IClientOptions };
 
 enum State {
   INITIALISED = "INITIALISED",

--- a/base_agent/js/src/index.ts
+++ b/base_agent/js/src/index.ts
@@ -4,9 +4,10 @@ import { InputPlug, OutputPlug } from "./Plug";
 import logger from "loglevel";
 import { LogLevelDesc } from "loglevel";
 import { TetherConfig, TetherOptions } from "./types";
+import { encode, decode } from "@msgpack/msgpack";
 
 logger.setLevel("info");
-export { logger, BROKER_DEFAULTS };
+export { logger, BROKER_DEFAULTS, encode, decode };
 
 export { InputPlug, OutputPlug, IClientOptions };
 

--- a/base_agent/js/src/index.ts
+++ b/base_agent/js/src/index.ts
@@ -15,14 +15,16 @@ export class TetherAgent {
   private client: AsyncMqttClient | null;
 
   /**
-   * Create a new Tether Agent, and connect automatically. This is an async function, so it will return the
-   * agent via the Promise only once the connection has been made successfully.
+   * Create a new Tether Agent, and connect automatically unless . This is an async
+   * function, so it will return the agent via the Promise only once the connection
+   * has been made successfully - or immediately if you turn autoConnect off.
    *
-   * @param agentRole The Role of this Agent in the system. Describes what this type of Agent does.
-   * @param agentID An optional identifier for the Agent. Could be a unique ID for this instance or something shared for a group of agents. Defaults to "any".
-   * @param mqttOptions Connection details (host, port, etc.) for the MQTT Broker. Leave this out to use defaults.
-   * @param loglevel Make the Tether library more verbose by setting "debug", for example.
-   * @returns
+   * @param role The Role of this Agent in the system. Describes what this type of Agent does.
+   * @param options Optional object which in turn has optional fields. Use this to override defaults
+   * as necessary. For example, `{ brokerOptions.BROKER_DEFAULTS.browser }` will switch MQTT Client
+   * options to use sensible defaults for WebSocket connections, instead of the default
+   * TCP connection which is more suitable for NodeJS applications.
+   * @returns A new TetherAgent instance
    */
   public static async create(
     role: string,

--- a/base_agent/js/src/index.ts
+++ b/base_agent/js/src/index.ts
@@ -54,8 +54,8 @@ export class TetherAgent {
       logger.setLevel(loglevel);
     }
     logger.info("Tether Agent instance:", {
-      agentType: agentRole,
-      agentId: this.agentID,
+      role: this.agentRole,
+      id: this.agentID,
     });
   }
 
@@ -64,7 +64,7 @@ export class TetherAgent {
     shouldRetry = true // if MQTT agent retries, it will not throw connection errors!
   ) => {
     const options: IClientOptions = {
-      ...defaults.broker,
+      ...defaults.nodeJS,
       ...overrides,
     };
     logger.info("Tether Agent connecting with options", options);

--- a/base_agent/js/src/types.ts
+++ b/base_agent/js/src/types.ts
@@ -1,13 +1,23 @@
 import { IClientOptions } from "async-mqtt";
 
-export interface Config {
-  nodeJS: IClientOptions;
-  browser: IClientOptions;
-}
-
 export interface PlugDefinition {
   name: string;
   topic: string;
 }
 
 export type MessageCallback = (payload: Buffer, topic: string) => void;
+
+export interface TetherConfig {
+  role: string;
+  id: string;
+  brokerOptions: IClientOptions;
+  autoConnect: boolean;
+}
+
+export interface TetherOptions {
+  role: string;
+  id?: string;
+  brokerOptions?: IClientOptions;
+  autoConnect: boolean;
+  loglevel?: string;
+}

--- a/base_agent/js/src/types.ts
+++ b/base_agent/js/src/types.ts
@@ -1,7 +1,8 @@
 import { IClientOptions } from "async-mqtt";
 
 export interface Config {
-  broker: IClientOptions;
+  nodeJS: IClientOptions;
+  browser: IClientOptions;
 }
 
 export interface PlugDefinition {

--- a/base_agent/js/src/types.ts
+++ b/base_agent/js/src/types.ts
@@ -15,9 +15,8 @@ export interface TetherConfig {
 }
 
 export interface TetherOptions {
-  role: string;
   id?: string;
   brokerOptions?: IClientOptions;
-  autoConnect: boolean;
+  autoConnect?: boolean;
   loglevel?: string;
 }

--- a/base_agent/js/tsconfig.json
+++ b/base_agent/js/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@tsconfig/node18",
   "compilerOptions": {
     "module": "commonjs",
     "esModuleInterop": true,
@@ -11,8 +12,5 @@
   "include": [
     "src/**/*"
   ],
-  "exclude": ["**/*.test.ts"],
-  "lib": [
-    "es6"
-  ]
+  "exclude": ["**/*.test.ts"]
 }

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -55,7 +55,6 @@ const main = async () => {
   }, 4000);
 
   const fastInput = await InputPlug.create(agent, "fastValuesReceiver");
-  console.log("typeof fastInput", typeof fastInput);
   fastInput.on("message", (payload) => {
     console.log("received fastValues");
   });

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -12,10 +12,14 @@ const config = parse(
 console.log("Launch with config", config);
 
 const main = async () => {
-  const agent = await TetherAgent.create({ role: "dummy" });
-  // setTimeout(() => {
-  //   agent.connect(config.clientOptions);
-  // }, 5000);
+  const agent = await TetherAgent.create("dummy");
+
+  // Example of custom options below:
+  // const agent = await TetherAgent.create("dummy", {
+  //   id: "special",
+  //   brokerOptions: BROKER_DEFAULTS.browser,
+  // });
+
   const outputPlug = new Output(agent, "randomValue");
   const emptyOutputPlug = new Output(agent, "emptyMessage");
 

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -3,10 +3,11 @@ const {
   InputPlug,
   OutputPlug,
   BROKER_DEFAULTS,
+  encode,
+  decode,
 } = require("tether-agent");
 const parse = require("parse-strings-in-object");
 const rc = require("rc");
-const { encode, decode } = require("@msgpack/msgpack");
 
 const config = parse(
   rc("NodeJSDummy", {

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -18,7 +18,9 @@ const config = parse(
 console.log("Launch with config", config);
 
 const main = async () => {
-  const agent = await TetherAgent.create("dummy");
+  const agent = await TetherAgent.create("dummy", {
+    loglevel: config.loglevel,
+  });
 
   // Example of custom options below:
   // const agent = await TetherAgent.create("dummy", {
@@ -40,7 +42,10 @@ const main = async () => {
   }, 1000);
 
   setTimeout(() => {
-    const fastOutput = new OutputPlug(agent, "fastValues");
+    const fastOutput = new OutputPlug(agent, "fastValues", undefined, {
+      qos: 0,
+      retain: false,
+    });
     setInterval(() => {
       const a = [Math.random(), Math.random(), Math.random()];
       fastOutput.publish(Buffer.from(encode(a)));

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -1,4 +1,4 @@
-const { TetherAgent, Input, Output } = require("tether-agent");
+const { TetherAgent, Input, Output, BROKER_DEFAULTS } = require("tether-agent");
 const parse = require("parse-strings-in-object");
 const rc = require("rc");
 const { encode, decode } = require("@msgpack/msgpack");
@@ -12,12 +12,7 @@ const config = parse(
 console.log("Launch with config", config);
 
 const main = async () => {
-  const agent = await TetherAgent.create(
-    "dummy",
-    undefined,
-    undefined,
-    config.loglevel
-  );
+  const agent = await TetherAgent.create({ role: "dummy" });
   // setTimeout(() => {
   //   agent.connect(config.clientOptions);
   // }, 5000);

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -54,19 +54,20 @@ const main = async () => {
     }, 10);
   }, 4000);
 
-  const fastInput = new InputPlug(agent, "fastValuesReceiver");
+  const fastInput = await InputPlug.create(agent, "fastValuesReceiver");
+  console.log("typeof fastInput", typeof fastInput);
   fastInput.on("message", (payload) => {
     console.log("received fastValues");
   });
 
-  const inputPlugOne = new InputPlug(agent, "randomValue");
+  const inputPlugOne = await InputPlug.create(agent, "randomValue");
   inputPlugOne.on("message", (payload, topic) => {
     console.log("received:", { payload, topic });
     const m = decode(payload);
     console.log("received message on inputPlugOne:", { topic, m });
   });
 
-  const inputPlugTwo = new InputPlug(agent, "moreRandomValues", {
+  const inputPlugTwo = await InputPlug.create(agent, "moreRandomValues", {
     overrideTopic: "dummy/NodeJSDummy/randomValue",
   });
   inputPlugTwo.on("message", (payload, topic) => {
@@ -74,7 +75,7 @@ const main = async () => {
     console.log("received message on inputPlugTwo:", { topic, m });
   });
 
-  const inputPlugThree = new InputPlug(agent, "evenMoreRandomValues", {
+  const inputPlugThree = await InputPlug.create(agent, "evenMoreRandomValues", {
     overrideTopic: "+/+/randomValue",
   });
   inputPlugThree.on("message", (payload, topic) => {
@@ -83,7 +84,7 @@ const main = async () => {
   });
 
   try {
-    const inputPlugFour = new InputPlug(agent, "randomValue", {
+    const inputPlugFour = await InputPlug.create(agent, "randomValue", {
       overrideTopic: "+/+/somethingElse",
     });
     inputPlugFour.on("message", () => {
@@ -96,7 +97,7 @@ const main = async () => {
   }
 
   let countReceived = 0;
-  const inputPlugJustOnce = new InputPlug(agent, "randomValueOnce");
+  const inputPlugJustOnce = await InputPlug.create(agent, "randomValueOnce");
   inputPlugJustOnce.once("message", (payload, topic) => {
     countReceived++;
     console.log("received", countReceived, "message on inputPlugJustOnce");
@@ -105,7 +106,7 @@ const main = async () => {
     }
   });
 
-  const inputEmptyMessages = new InputPlug(agent, "emptyMessage");
+  const inputEmptyMessages = await InputPlug.create(agent, "emptyMessage");
   inputEmptyMessages.on("message", (payload, topic) => {
     console.log("received empty message:", { payload, topic });
   });

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -1,4 +1,9 @@
-const { TetherAgent, Input, Output, BROKER_DEFAULTS } = require("tether-agent");
+const {
+  TetherAgent,
+  InputPlug,
+  OutputPlug,
+  BROKER_DEFAULTS,
+} = require("tether-agent");
 const parse = require("parse-strings-in-object");
 const rc = require("rc");
 const { encode, decode } = require("@msgpack/msgpack");
@@ -20,8 +25,8 @@ const main = async () => {
   //   brokerOptions: BROKER_DEFAULTS.browser,
   // });
 
-  const outputPlug = new Output(agent, "randomValue");
-  const emptyOutputPlug = new Output(agent, "emptyMessage");
+  const outputPlug = new OutputPlug(agent, "randomValue");
+  const emptyOutputPlug = new OutputPlug(agent, "emptyMessage");
 
   setInterval(() => {
     const m = {
@@ -34,26 +39,30 @@ const main = async () => {
   }, 1000);
 
   setTimeout(() => {
-    const fastOutput = new Output(agent, "fastValues");
+    const fastOutput = new OutputPlug(agent, "fastValues");
     setInterval(() => {
       const a = [Math.random(), Math.random(), Math.random()];
       fastOutput.publish(Buffer.from(encode(a)));
     }, 10);
   }, 4000);
 
-  const fastInput = new Input(agent, "fastValuesReceiver", "+/+/fastValues");
+  const fastInput = new InputPlug(
+    agent,
+    "fastValuesReceiver",
+    "+/+/fastValues"
+  );
   fastInput.on("message", (payload) => {
     console.log("received fastValues");
   });
 
-  const inputPlugOne = new Input(agent, "randomValue");
+  const inputPlugOne = new InputPlug(agent, "randomValue");
   inputPlugOne.on("message", (payload, topic) => {
     console.log("received:", { payload, topic });
     const m = decode(payload);
     console.log("received message on inputPlugOne:", { topic, m });
   });
 
-  const inputPlugTwo = new Input(
+  const inputPlugTwo = new InputPlug(
     agent,
     "moreRandomValues",
     "dummy/NodeJSDummy/randomValue"
@@ -63,7 +72,7 @@ const main = async () => {
     console.log("received message on inputPlugTwo:", { topic, m });
   });
 
-  const inputPlugThree = new Input(
+  const inputPlugThree = new InputPlug(
     agent,
     "evenMoreRandomValues",
     "+/+/randomValue"
@@ -74,7 +83,11 @@ const main = async () => {
   });
 
   try {
-    const inputPlugFour = new Input(agent, "randomValue", "+/+/somethingElse");
+    const inputPlugFour = new InputPlug(
+      agent,
+      "randomValue",
+      "+/+/somethingElse"
+    );
     inputPlugFour.on("message", () => {
       throw Error(
         "we didn't expect to receive anything on this plug, despite the name"
@@ -85,7 +98,7 @@ const main = async () => {
   }
 
   let countReceived = 0;
-  const inputPlugJustOnce = new Input(
+  const inputPlugJustOnce = new InputPlug(
     agent,
     "randomValueOnce",
     "+/+/randomValue"
@@ -98,7 +111,7 @@ const main = async () => {
     }
   });
 
-  const inputEmptyMessages = new Input(agent, "emptyMessage");
+  const inputEmptyMessages = new InputPlug(agent, "emptyMessage");
   inputEmptyMessages.on("message", (payload, topic) => {
     console.log("received empty message:", { payload, topic });
   });

--- a/examples/nodejs/index.js
+++ b/examples/nodejs/index.js
@@ -42,9 +42,11 @@ const main = async () => {
   }, 1000);
 
   setTimeout(() => {
-    const fastOutput = new OutputPlug(agent, "fastValues", undefined, {
-      qos: 0,
-      retain: false,
+    const fastOutput = new OutputPlug(agent, "fastValues", {
+      publishOptions: {
+        qos: 0,
+        retain: false,
+      },
     });
     setInterval(() => {
       const a = [Math.random(), Math.random(), Math.random()];
@@ -52,11 +54,7 @@ const main = async () => {
     }, 10);
   }, 4000);
 
-  const fastInput = new InputPlug(
-    agent,
-    "fastValuesReceiver",
-    "+/+/fastValues"
-  );
+  const fastInput = new InputPlug(agent, "fastValuesReceiver");
   fastInput.on("message", (payload) => {
     console.log("received fastValues");
   });
@@ -68,35 +66,29 @@ const main = async () => {
     console.log("received message on inputPlugOne:", { topic, m });
   });
 
-  const inputPlugTwo = new InputPlug(
-    agent,
-    "moreRandomValues",
-    "dummy/NodeJSDummy/randomValue"
-  );
+  const inputPlugTwo = new InputPlug(agent, "moreRandomValues", {
+    overrideTopic: "dummy/NodeJSDummy/randomValue",
+  });
   inputPlugTwo.on("message", (payload, topic) => {
     const m = decode(payload);
     console.log("received message on inputPlugTwo:", { topic, m });
   });
 
-  const inputPlugThree = new InputPlug(
-    agent,
-    "evenMoreRandomValues",
-    "+/+/randomValue"
-  );
+  const inputPlugThree = new InputPlug(agent, "evenMoreRandomValues", {
+    overrideTopic: "+/+/randomValue",
+  });
   inputPlugThree.on("message", (payload, topic) => {
     const m = decode(payload);
     console.log("received message on inputPlugThree:", { topic, m });
   });
 
   try {
-    const inputPlugFour = new InputPlug(
-      agent,
-      "randomValue",
-      "+/+/somethingElse"
-    );
+    const inputPlugFour = new InputPlug(agent, "randomValue", {
+      overrideTopic: "+/+/somethingElse",
+    });
     inputPlugFour.on("message", () => {
       throw Error(
-        "we didn't expect to receive anything on this plug, despite the name"
+        "we didn't expect to receive anything on this plug, despite the name match"
       );
     });
   } catch (e) {
@@ -104,11 +96,7 @@ const main = async () => {
   }
 
   let countReceived = 0;
-  const inputPlugJustOnce = new InputPlug(
-    agent,
-    "randomValueOnce",
-    "+/+/randomValue"
-  );
+  const inputPlugJustOnce = new InputPlug(agent, "randomValueOnce");
   inputPlugJustOnce.once("message", (payload, topic) => {
     countReceived++;
     console.log("received", countReceived, "message on inputPlugJustOnce");

--- a/examples/nodejs/package-lock.json
+++ b/examples/nodejs/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@msgpack/msgpack": "^2.7.2",
         "parse-strings-in-object": "^1.4.0",
         "rc": "^1.2.8",
         "tether-agent": "../../base_agent/js"
@@ -19,13 +18,13 @@
       }
     },
     "../../base_agent/js": {
-      "version": "2.7.2",
+      "name": "tether-agent",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "async-mqtt": "^2.6.2",
         "buffer": "^6.0.3",
-        "loglevel": "^1.8.0",
-        "uuid": "^8.3.2"
+        "loglevel": "^1.8.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -36,14 +35,6 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.5.5"
-      }
-    },
-    "node_modules/@msgpack/msgpack": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.7.2.tgz",
-      "integrity": "sha512-rYEi46+gIzufyYUAoHDnRzkWGxajpD9vVXFQ3g1vbjrBm6P7MBmm+s/fqPa46sxa+8FOUdEuRQKaugo5a4JWpw==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/deep-extend": {
@@ -109,11 +100,6 @@
     }
   },
   "dependencies": {
-    "@msgpack/msgpack": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.7.2.tgz",
-      "integrity": "sha512-rYEi46+gIzufyYUAoHDnRzkWGxajpD9vVXFQ3g1vbjrBm6P7MBmm+s/fqPa46sxa+8FOUdEuRQKaugo5a4JWpw=="
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -169,8 +155,7 @@
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^4.5.5",
-        "uuid": "^8.3.2"
+        "typescript": "^4.5.5"
       }
     }
   }

--- a/examples/nodejs/package-lock.json
+++ b/examples/nodejs/package-lock.json
@@ -22,6 +22,7 @@
       "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
+        "@msgpack/msgpack": "^3.0.0-beta2",
         "async-mqtt": "^2.6.2",
         "buffer": "^6.0.3",
         "loglevel": "^1.8.0"
@@ -145,6 +146,7 @@
     "tether-agent": {
       "version": "file:../../base_agent/js",
       "requires": {
+        "@msgpack/msgpack": "^3.0.0-beta2",
         "@types/jest": "^28.1.6",
         "@types/node": "^15.0.3",
         "@types/uuid": "^8.3.4",

--- a/examples/nodejs/package-lock.json
+++ b/examples/nodejs/package-lock.json
@@ -1,20 +1,41 @@
 {
   "name": "tether-nodejs-example",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tether-nodejs-example",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@msgpack/msgpack": "^2.7.2",
         "parse-strings-in-object": "^1.4.0",
-        "rc": "^1.2.8"
+        "rc": "^1.2.8",
+        "tether-agent": "../../base_agent/js"
       },
       "devDependencies": {
         "prettier": "^2.2.1"
+      }
+    },
+    "../../base_agent/js": {
+      "version": "2.7.2",
+      "license": "ISC",
+      "dependencies": {
+        "async-mqtt": "^2.6.2",
+        "buffer": "^6.0.3",
+        "loglevel": "^1.8.0",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "@types/jest": "^28.1.6",
+        "@types/node": "^15.0.3",
+        "@types/uuid": "^8.3.4",
+        "jest": "^28.1.3",
+        "ts-jest": "^28.0.7",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^4.5.5"
       }
     },
     "node_modules/@msgpack/msgpack": {
@@ -81,6 +102,10 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tether-agent": {
+      "resolved": "../../base_agent/js",
+      "link": true
     }
   },
   "dependencies": {
@@ -130,6 +155,23 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "tether-agent": {
+      "version": "file:../../base_agent/js",
+      "requires": {
+        "@types/jest": "^28.1.6",
+        "@types/node": "^15.0.3",
+        "@types/uuid": "^8.3.4",
+        "async-mqtt": "^2.6.2",
+        "buffer": "^6.0.3",
+        "jest": "^28.1.3",
+        "loglevel": "^1.8.0",
+        "ts-jest": "^28.0.7",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^4.5.5",
+        "uuid": "^8.3.2"
+      }
     }
   }
 }

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "tether-agent": "../../base_agent/js",
     "@msgpack/msgpack": "^2.7.2",
     "parse-strings-in-object": "^1.4.0",
     "rc": "^1.2.8"

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -9,10 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "tether-agent": "../../base_agent/js",
-    "@msgpack/msgpack": "^2.7.2",
     "parse-strings-in-object": "^1.4.0",
-    "rc": "^1.2.8"
+    "rc": "^1.2.8",
+    "tether-agent": "../../base_agent/js"
   },
   "devDependencies": {
     "prettier": "^2.2.1"


### PR DESCRIPTION
At long last, this update gets round to improving the Javascript API - the JS Base Agent. It is a breaking change - not backwards-compatible - so it moves the JS Base Agent to v3.

TLDR; check out the `./examples/js/index.js` to see the new API in action. The differences are easy to spot if you're used to the old way.

# Major Changes

## Plugs are not stored 
We used to use methods on the TetherAgent class (`.createInput` and .`createOutput`) which not only created the Plug definition but also did **two** things:

- Added the new Plug to a private (internal) array of `inputs[]` and `outputs[]`
- Returned the Plug 

This potentially created some confusion: who "owns" the Plug? Is it the Tether Agent instance, or a variable stored by the end-user developer somewhere? Both?

In v3, plugs are created by calling 
- `new OutputPlug(...)` for Output Plugs - this is synchronous
- `await InputPlug.create(...)` for Input Plugs - this is **async** because it forces the end-user to wait for subscription to happen before using the Plug!

> For some reason, it is still possible to call `new InputPlug` and `new TetherAgent` even though these are both defined explicitly as `private constructor`, yet no error is thrown. JS isn't supposed to have private constructors, but TS definitely does. Seems to work in a TypeScript environment as expected (see below), but JS allows such silliness.

<img width="872" alt="Screenshot 2023-11-03 at 17 01 56" src="https://github.com/RandomStudio/tether/assets/3015222/43be834f-2580-439a-a2ae-6368bbdab1ed">

Notice also that these are called `InputPlug` and `OutputPlug` now instead of the old `Input` and `Output` - this avoids some potential naming clashes and seems clearer.

The `agent` instance is passed in with the constructor in order to:
- build sensible default topics based on the Agent Role and ID as necessary
- allow messages to be published via `.publish(...)` in the case of OutputPlug
- allow standard Events to be emitted via `.on("message", ...)` when matching incoming messages in the case of InputPlug

One implication of this which might not be obvious at first: messages will be checked by each InputPlug rather than only "once" inside the TetherAgent instance. The InputPlug instances keep a reference to the agent (not the other way around, as previously), so they do `this.agent.getClient().on("message" ...`. This might be slightly more inefficient, since all incoming messages propagate Events regardless of which InputPlug they "belong" to, but only the topic is parsed at this stage (not the MessagePack contents, for example) so it's probably a minimal impact.

Each OutputPlug instance also retains a reference to the TetherAgent instance, which it uses for publishing.

In summary: the end-user developer needs to look after instances of InputPlug and OutputPlug themselves, and cannot call `.getInput` or `.getOutput` since the Plugs are not saved somewhere "else". This hopefully makes things clearer, and ensures that the developer focusses on the Plug level without having to also consider a somewhat abstract relation between Plugs and the TetherAgent.

## Better defaults, better optional parameters
### For TetherAgent
For `TetherAgent.create` the only required parameter is the `role`, which you always need to provide. The other parameter is `options?: TetherOptions` - it is both an optional parameter **and** the fields in the object are all optional! This makes it easy to pass in only the override options you need, e.g. `TetherAgent.create("mySpecialAgent", { id: "specificGroup" }` will only override the agent `ID`.

Even more useful is that what used to be called `overrides` (MQTT `IClientOptions`) is now labelled specifically `brokerOptions`, and we provide two default objects that are suitable for NodeJS/TCP and Browser/WebSocket connections respectively. By default, we use the NodeJS/TCP settings, but for web applications you set things up very easily with something like this:
```
import { TetherAgent, BROKER_DEFAULTS } from "tether-agent";
const agent = await TetherAgent.create("browserApplication", {
  brokerOptions: BROKER_DEFAULTS.browser,
});
```
... No need to remember to change protocol, port number, path, etc.

Another convenience: for both `BROKER_DEFAULTS.nodeJS` and `BROKER_DEFAULTS.browser` we connect to the MQTT Broker at `localhost` with the standard username+password for Tether as per our standard Docker setup and all other utilities developed so far. Of course, you can override any of this, but there is less to remember!

### Catching the weird "host" vs "hostname" quirk
The JS MQTT library has always behaved strangely when you change the `host` property but not the `hostname` property at the same time. The result is that `host` is effectively ignored, and you find yourself being connected to the wrong host name or IP address!

Yes, we could tell all users to always set both "host" and "hostname" together. But why not just auto-detect this situation and fix it for them? v3 does this: if the user specifies a "host" but forgets "hostname", we just set "hostname" to the same thing as the user specified for "host". Problem solved.

### For Plugs
`OutputPlug` now has a constructor with arguments as follows:
```
 agent: TetherAgent,
    name: string,
    options?: {
      overrideTopic?: string;
      publishOptions?: IClientPublishOptions;
    }
```
Notice that only the "name" is required. 

A key difference from the earlier version: `IClientPublishOptions` are provided at **instantiation** rather than on `.publish`. Defaults are used if nothing is provided. In other words, this config is **saved** and used for every `.publish` call, which seems more sensible.

Similarly, `InputPlug` now has a factory method `async create` with the following arguments
```
 agent: TetherAgent,
    name: string,
    options?: {
      overrideTopic?: string;
      subscribeOptions?: IClientSubscribeOptions;
    }
```
Again, only the "name" is required. The options for subscription get saved, same as for OutputPlug (this used to be inconsistent - Input(Plug) would save these options but Output(Plug) would not).

**Very important: there is no public or implicit `.subscribe` method any more.** Creating an Input Plug is assumed to be synonymous with subscribing. Previously, the end-user could either call `.subscribe` themselves or - confusingly - do an implicit `.subscribe` when calling `.onMessage` or `onMessageOnce`! This seemed like a very niche case to provide for, and just made things potentially confusing at times.

## Automatic (or manual) Connecting is simplified
Previously, we had a private method `.connect(overrides?: IClientOptions)` on `TetherAgent`. Confusingly, you could override some things related to the MQTT connection at this point rather than on `TetherAgent.create` in the first place... 

Instead, `.connect()` now takes no parameters, because it simply uses whatever has been set up in the `.create` stage (whether defaults, overrides or a combination of the two). 

The function is also `public` because we now allow you to set `{ autoConnect: false }` when creating a Tether Agent in case you have reason to create the TetherAgent instance first without automatically connecting as well.

## MessagePack included
The library `@msgpack/msgpack` is now included in the JS Base Agent itself as a dependency, and the `encode` and `decode` functions are exported from the library.

MessagePack works great, so why not?

This means that future client applications only need to include "tether-agent" as a dependency, and they get the MessagePack encoding and decoding as well without needing to remember a separate library.

This also means that, in future, we could easily provide (optional?) automatic encode-and-publish and/or automatic receive-and-decode functionality in the Base Agent if we like. We already do something like this in the Rust Base Agent, for example.

## Connection/state changes
The function `getIsConnected` was surprisingly unreliable at reporting whether the Tether Agent (MQTT client) was actually connected or not.

The `client` from the MQTT library will apparently return `true` for `.isConnected` even when the connection has failed.

The v3 Tether Agent therefore keeps track of the State (INITIALISING, CONNECTING, CONNECTED, ERRORED) a lot more carefully, and tries to report `getIsConnected()` more reliably.

## Minor Changes
- `Input` -> `InputPlug` and `Output` -> `OutputPlug`
- There is no special `onMessage`or `.onMessageOnce` function for Input(Plug)s - a standard Event Emitter pattern is used instead, i.e. `.on("message", (payload, topic) => {})` and `.once("message", (payload, topic) => {})`
- Subscribing without an active connection is not (currently) allowed any more. Can't think of any reason to allow it, and makes even less sense when the Plugs are "owned" by the end-user application rather than the TetherAgent instance; how would we ensure that actual subscription is done "later"?
- Utility functions such as "parsePlugName" relating to Plugs have been moved to `Plugs.ts`
- UUID library has been removed completely, because it generates very lengthy "ID" strings that are hard to read and not very useful. In the meantime the concept of an Agent "ID" has been extended to a "grouping" so it makes even less sense to generate such unique identities by default. If the end-user needs to group (or distinguish/split) agents with such granularity then they should rather do this explicitly, themselves. For example, it might make more sense to use a MAC ID or some other identifier. Now, we default to `"any"` instead.
- Added `getState()` function which can give more detail than `getIsConnected()` on its own
