### PR TITLE
match using TetherOrCustomTopic

### DIFF
--- a/base_agent/rs/examples/custom_options.rs
+++ b/base_agent/rs/examples/custom_options.rs
@@ -33,7 +33,7 @@ fn main() {
 
     if let PlugDefinition::OutputPlug(p) = output_plug.unwrap() {
         println!("output plug: {:?}", p);
-        assert_eq!(p.topic(), "pretendingToBeSomethingElse/any/anOutput");
+        assert_eq!(p.topic_str(), "pretendingToBeSomethingElse/any/anOutput");
     }
 
     println!("wildcard input plug: {:?}", input_wildcard_plug);

--- a/base_agent/rs/examples/subscribe.rs
+++ b/base_agent/rs/examples/subscribe.rs
@@ -71,7 +71,7 @@ fn main() {
                 topic_parts
             );
 
-            if input_one.matches(message.topic()) {
+            if input_one.matches(&topic_parts) {
                 info!(
                             "******** INPUT ONE:\n Received a message for plug named \"{}\" on topic {} with length {} bytes",
                             input_one.name(),
@@ -80,7 +80,7 @@ fn main() {
                         );
                 assert_eq!(parse_plug_name(message.topic()), Some("one"));
             }
-            if input_two.matches(message.topic()) {
+            if input_two.matches(&topic_parts) {
                 info!(
                         "******** INPUT TWO:\n Received a message for plug named \"{}\" on topic {} with length {} bytes",
                         input_two.name(),
@@ -103,7 +103,7 @@ fn main() {
                     }
                 };
             }
-            if input_empty.matches(message.topic()) {
+            if input_empty.matches(&topic_parts) {
                 info!(
                         "******** EMPTY MESSAGE:\n Received a message for plug named \"{}\" on topic {} with length {} bytes",
                         input_empty.name(),
@@ -112,7 +112,7 @@ fn main() {
                     );
                 assert_eq!(parse_plug_name(message.topic()), Some("nothing"));
             }
-            if input_everything.matches(message.topic()) {
+            if input_everything.matches(&topic_parts) {
                 info!(
                     "******** EVERYTHING MATCHES HERE:\n Received a message for plug named \"{}\" on topic {} with length {} bytes",
                     input_everything.name(),
@@ -120,7 +120,7 @@ fn main() {
                     message.payload().len()
                 );
             }
-            if input_specify_id.matches(message.topic()) {
+            if input_specify_id.matches(&topic_parts) {
                 info!("******** ID MATCH:\n Should match any role and plug name, but only messages with ID \"groupMessages\"");
                 info!(
                     "\n Received a message from plug named \"{}\" on topic {} with length {} bytes",

--- a/base_agent/rs/src/agent/mod.rs
+++ b/base_agent/rs/src/agent/mod.rs
@@ -233,7 +233,7 @@ impl TetherAgent {
                 panic!("You cannot publish using an Input Plug")
             }
             PlugDefinition::OutputPlug(output_plug_definition) => {
-                let topic = output_plug_definition.topic();
+                let topic = output_plug_definition.topic_str();
                 let qos = output_plug_definition.qos();
                 let message = MessageBuilder::new()
                     .topic(topic)

--- a/base_agent/rs/src/plugs/definitions.rs
+++ b/base_agent/rs/src/plugs/definitions.rs
@@ -1,11 +1,12 @@
-use log::{debug, error};
+use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 
 use crate::three_part_topic::ThreePartTopic;
 
 pub trait PlugDefinitionCommon<'a> {
     fn name(&'a self) -> &'a str;
-    fn topic(&'a self) -> &'a str;
+    fn topic_str(&'a self) -> &'a str;
+    fn topic(&'a self) -> &'a TetherOrCustomTopic;
     fn qos(&'a self) -> i32;
 }
 
@@ -26,7 +27,7 @@ impl PlugDefinitionCommon<'_> for InputPlugDefinition {
         &self.name
     }
 
-    fn topic(&self) -> &str {
+    fn topic_str(&self) -> &str {
         match &self.topic {
             TetherOrCustomTopic::Custom(s) => {
                 debug!("Plug named \"{}\" has custom topic \"{}\"", &self.name, &s);
@@ -40,6 +41,10 @@ impl PlugDefinitionCommon<'_> for InputPlugDefinition {
                 t.topic()
             }
         }
+    }
+
+    fn topic(&'_ self) -> &'_ TetherOrCustomTopic {
+        &self.topic
     }
 
     fn qos(&self) -> i32 {
@@ -66,18 +71,20 @@ impl InputPlugDefinition {
     /// In the case where an Input Plug was defined with a completely manually-specified topic string,
     /// this function returns a warning and marks ANY incoming message as a valid match; the end-user
     /// developer is expected to match against topic strings themselves.
-    pub fn matches(&self, topic: &str) -> bool {
-        match &self.topic {
-            TetherOrCustomTopic::Custom(s) => {
-                debug!(
-                    "Custom/manual topic \"{}\" on Plug \"{}\" cannot be matched automatically; please filter manually for this",
-                    &s,
-                    self.name()
-                );
-                true
-            }
-            TetherOrCustomTopic::Tether(my_tpt) => {
-                if let Ok(incoming_three_parts) = ThreePartTopic::try_from(topic) {
+    pub fn matches(&self, incoming_topic: &TetherOrCustomTopic) -> bool {
+        // match &self.topic {
+        //     TetherOrCustomTopic::Custom(s) => {
+        //         debug!(
+        //             "Custom/manual topic \"{}\" on Plug \"{}\" cannot be matched automatically; please filter manually for this",
+        //             &s,
+        //             self.name()
+        //         );
+        //         true
+        //     }
+        // TetherOrCustomTopic::Tether(my_tpt) => {
+        match incoming_topic {
+            TetherOrCustomTopic::Tether(incoming_three_parts) => match &self.topic {
+                TetherOrCustomTopic::Tether(my_tpt) => {
                     let matches_role =
                         my_tpt.role() == "+" || my_tpt.role().eq(incoming_three_parts.role());
                     let matches_id =
@@ -86,11 +93,41 @@ impl InputPlugDefinition {
                         || my_tpt.plug_name().eq(incoming_three_parts.plug_name());
                     debug!("Test match for plug named \"{}\" with def {:?} against {:?} => matches_role? {}, matches_id? {}, matches_plug_name? {}", &self.name, &self.topic, &incoming_three_parts, matches_role, matches_id, matches_plug_name);
                     matches_role && matches_id && matches_plug_name
-                } else {
-                    error!("Incoming topic \"{}\" is not a three-part topic", topic);
+                }
+                TetherOrCustomTopic::Custom(my_custom_topic) => {
+                    debug!(
+                    "Custom/manual topic \"{}\" on Plug \"{}\" cannot be matched automatically; please filter manually for this",
+                    &my_custom_topic,
+                    self.name()
+                );
+                    if my_custom_topic.as_str() == "#"
+                        || my_custom_topic.as_str() == incoming_three_parts.topic()
+                    {
+                        true
+                    } else {
+                        false
+                    }
+                }
+            },
+            TetherOrCustomTopic::Custom(incoming_custom) => match &self.topic {
+                TetherOrCustomTopic::Custom(my_custom_topic) => {
+                    if my_custom_topic.as_str() == "#"
+                        || my_custom_topic.as_str() == incoming_custom.as_str()
+                    {
+                        true
+                    } else {
+                        warn!(
+                            "Incoming topic \"{}\" is not a three-part topic",
+                            &incoming_custom
+                        );
+                        false
+                    }
+                }
+                TetherOrCustomTopic::Tether(_) => {
+                    error!("Incoming is NOT Three Part Topic but this plug DOES have Three Part Topic; cannot decide match");
                     false
                 }
-            }
+            },
         }
     }
 }
@@ -108,11 +145,15 @@ impl PlugDefinitionCommon<'_> for OutputPlugDefinition {
         &self.name
     }
 
-    fn topic(&self) -> &str {
+    fn topic_str(&self) -> &str {
         match &self.topic {
             TetherOrCustomTopic::Custom(s) => s,
             TetherOrCustomTopic::Tether(t) => t.topic(),
         }
+    }
+
+    fn topic(&'_ self) -> &'_ TetherOrCustomTopic {
+        &self.topic
     }
 
     fn qos(&'_ self) -> i32 {
@@ -156,12 +197,12 @@ impl PlugDefinition {
 
     pub fn topic(&self) -> &str {
         match self {
-            PlugDefinition::InputPlug(p) => p.topic(),
-            PlugDefinition::OutputPlug(p) => p.topic(),
+            PlugDefinition::InputPlug(p) => p.topic_str(),
+            PlugDefinition::OutputPlug(p) => p.topic_str(),
         }
     }
 
-    pub fn matches(&self, topic: &str) -> bool {
+    pub fn matches(&self, topic: &TetherOrCustomTopic) -> bool {
         match self {
             PlugDefinition::InputPlug(p) => p.matches(topic),
             PlugDefinition::OutputPlug(_) => {
@@ -176,7 +217,7 @@ impl PlugDefinition {
 mod tests {
 
     use crate::{
-        three_part_topic::{parse_agent_id, parse_agent_role, parse_plug_name, ThreePartTopic},
+        three_part_topic::{parse_plug_name, ThreePartTopic},
         InputPlugDefinition, PlugDefinitionCommon, TetherOrCustomTopic,
     };
 
@@ -191,10 +232,21 @@ mod tests {
         );
 
         assert_eq!(&plug_def.name, "testPlug");
-        assert_eq!(plug_def.topic(), "+/+/testPlug");
+        assert_eq!(plug_def.topic_str(), "+/+/testPlug");
         assert_eq!(parse_plug_name("+/+/testPlug"), Some("testPlug"));
-        assert!(plug_def.matches("dummy/any/testPlug"));
-        assert!(!plug_def.matches("dummy/any/anotherPlug"))
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "dummy", "any", "testPlug"
+            )))
+        );
+        assert!(
+            !plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "dummy",
+                "any",
+                "anotherPlug"
+            )))
+        );
+        // assert!(!plug_def.matches(&TetherOrCustomTopic::Custom("dummy/any/anotherPlug".into())));
     }
 
     #[test]
@@ -211,11 +263,35 @@ mod tests {
         );
 
         assert_eq!(&plug_def.name, "customPlug");
-        assert_eq!(plug_def.topic(), "customRole/+/customPlug");
-        assert!(plug_def.matches("customRole/any/customPlug"));
-        assert!(plug_def.matches("customRole/andAnythingElse/customPlug"));
-        assert!(!plug_def.matches("customRole/any/notMyPlug")); // wrong incoming Plug Name
-        assert!(!plug_def.matches("someOtherRole/any/customPlug")); // wrong incoming Role
+        assert_eq!(plug_def.topic_str(), "customRole/+/customPlug");
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "customRole",
+                "any",
+                "customPlug"
+            )))
+        );
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "customRole",
+                "andAnythingElse",
+                "customPlug"
+            )))
+        );
+        assert!(
+            !plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "customRole",
+                "any",
+                "notMyPlug"
+            )))
+        ); // wrong incoming Plug N.into())ame
+        assert!(
+            !plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "someOtherRole",
+                "any",
+                "customPlug"
+            )))
+        ); // wrong incoming R.into())ole
     }
 
     #[test]
@@ -232,11 +308,35 @@ mod tests {
         );
 
         assert_eq!(&plug_def.name, "customPlug");
-        assert_eq!(plug_def.topic(), "+/specificID/customPlug");
-        assert!(plug_def.matches("anyRole/specificID/customPlug"));
-        assert!(plug_def.matches("anotherRole/specificID/customPlug"));
-        assert!(!plug_def.matches("anyRole/specificID/notMyPlug")); // wrong incoming Plug Name
-        assert!(!plug_def.matches("anyRole/anotherID/customPlug")); // wrong incoming ID
+        assert_eq!(plug_def.topic_str(), "+/specificID/customPlug");
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "anyRole",
+                "specificID",
+                "customPlug"
+            )))
+        );
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "anotherRole",
+                "specificID",
+                "customPlug"
+            )))
+        ); // wrong incoming Role
+        assert!(
+            !plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "anyRole",
+                "specificID",
+                "notMyPlug"
+            )))
+        ); // wrong incoming Plug Name
+        assert!(
+            !plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "anyRole",
+                "anotherID",
+                "customPlug"
+            )))
+        ); // wrong incoming ID
     }
 
     #[test]
@@ -253,28 +353,63 @@ mod tests {
         );
 
         assert_eq!(&plug_def.name, "customPlug");
-        assert_eq!(plug_def.topic(), "specificRole/specificID/customPlug");
-        assert!(plug_def.matches("specificRole/specificID/customPlug"));
-        assert!(!plug_def.matches("specificRole/specificID/notMyPlug")); // wrong incoming Plug Name
-        assert!(!plug_def.matches("specificRole/anotherID/customPlug")); // wrong incoming ID
-        assert!(!plug_def.matches("anotherRole/anotherID/customPlug")); // wrong incoming Role
+        assert_eq!(plug_def.topic_str(), "specificRole/specificID/customPlug");
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "specificRole",
+                "specificID",
+                "customPlug"
+            )))
+        );
+        assert!(!plug_def.matches(&TetherOrCustomTopic::Custom(
+            "specificRole/specificID/notMyPlug".into()
+        ))); // wrong incoming Plug N.into())ame
+        assert!(!plug_def.matches(&TetherOrCustomTopic::Custom(
+            "specificRole/anotherID/customPlug".into()
+        ))); // wrong incoming.into()) ID
+        assert!(!plug_def.matches(&TetherOrCustomTopic::Custom(
+            "anotherRole/anotherID/customPlug".into()
+        ))); // wrong incoming R.into())ole
     }
 
     #[test]
     fn input_match_custom_topic() {
         let plug_def = InputPlugDefinition::new(
             "customPlug",
-            TetherOrCustomTopic::Custom("one/two/three".into()),
+            TetherOrCustomTopic::Custom("one/two/three/four/five".into()), // not a standard Tether Three Part Topic
             None,
         );
 
-        let incoming_topic = String::from("some/other/plug");
-
         assert_eq!(plug_def.name(), "customPlug");
-        assert!(plug_def.matches(&incoming_topic)); // it will match, but emit warning
+        // it will match on exactly the same topic:
+        assert!(plug_def.matches(&TetherOrCustomTopic::Custom(
+            "one/two/three/four/five".into()
+        )));
 
-        assert_eq!(parse_plug_name(&incoming_topic), Some("plug"));
-        assert_eq!(parse_agent_role(&incoming_topic), Some("some"));
-        assert_eq!(parse_agent_id(&incoming_topic), Some("other"));
+        // it will NOT match on anything else:
+        assert!(!plug_def.matches(&TetherOrCustomTopic::Custom("one/one/one/one/one".into())));
+    }
+
+    #[test]
+    fn input_match_wildcard() {
+        let plug_def = InputPlugDefinition::new(
+            "everything",
+            TetherOrCustomTopic::Custom("#".into()), // fully legal, but not a standard Three Part Topic
+            None,
+        );
+
+        assert_eq!(plug_def.name(), "everything");
+
+        // Standard TPT will match
+        assert!(
+            plug_def.matches(&TetherOrCustomTopic::Tether(ThreePartTopic::new(
+                "any", "any", "plugName"
+            )))
+        );
+
+        // Anything will match, even custom incoming
+        assert!(plug_def.matches(&TetherOrCustomTopic::Custom(
+            "one/two/three/four/five".into()
+        )));
     }
 }

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -220,10 +220,10 @@ impl PlugOptionsBuilder {
                     InputPlugDefinition::new(&plug_options.plug_name, tpt, plug_options.qos);
                 match tether_agent
                     .client()
-                    .subscribe(&plug_definition.topic(), plug_definition.qos())
+                    .subscribe(&plug_definition.topic_str(), plug_definition.qos())
                 {
                     Ok(res) => {
-                        debug!("This topic was fine: \"{}\"", plug_definition.topic());
+                        debug!("This topic was fine: \"{}\"", plug_definition.topic_str());
                         debug!("Server respond OK for subscribe: {res:?}");
                         Ok(PlugDefinition::InputPlug(plug_definition))
                     }


### PR DESCRIPTION
Use `CustomOrTetherTopic` (as provided by `check_messages` results), rather than relying on `message.topic()` (and then ignoring the `CustomOrTetherTopic` part!)

