### PR TITLE
Fix/expect name wildcard

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
         "--manifest-path", "${workspaceFolder}/utilities/tether-utils/Cargo.toml"
       ]
     },
-    "args": ["topics"]
+    "args": ["receive", "--plug.role=custom"]
   },
   {
     "name": "Launch NodeJS example",

--- a/base_agent/rs/Cargo.lock
+++ b/base_agent/rs/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/base_agent/rs/Cargo.toml
+++ b/base_agent/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-agent"
 description = "Standardised use of MQTT and MessagePack for inter-process communication"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -138,7 +138,7 @@ impl PlugOptionsBuilder {
                 if let Some(s) = override_plug_name {
                     if s.eq("+") {
                         info!(
-                            "Plug Name part given is a wildcard; subscribe topic will use this but Plug Name will remain unchanged"
+                            "Plug Name part given is a wildcard; subscribe topic will use this but (internally) Plug Name will remain \"{}\"", &opt.plug_name
                         );
                     } else {
                         error!("Input Plugs cannot change their name after ::create_input constructor EXCEPT for wildcard \"+\"");

--- a/base_agent/rs/src/plugs/three_part_topic.rs
+++ b/base_agent/rs/src/plugs/three_part_topic.rs
@@ -36,12 +36,12 @@ impl ThreePartTopic {
     /// topic is changed but the plug name itself is left alone.
     pub fn new_for_subscribe(
         plug_name: &str,
-        role: Option<&str>,
-        id: Option<&str>,
+        role_part_override: Option<&str>,
+        id_part_override: Option<&str>,
         plug_name_part_override: Option<&str>,
     ) -> ThreePartTopic {
-        let role = role.unwrap_or("+");
-        let id = id.unwrap_or("+");
+        let role = role_part_override.unwrap_or("+");
+        let id = id_part_override.unwrap_or("+");
         let plug_name_part = match plug_name_part_override {
             Some(s) => {
                 if !&s.eq("+") {

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -741,9 +741,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda9da2b544292584335d866a2656af255af77823e71a6ca04147d9101478af"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/utilities/tether-utils/Cargo.lock
+++ b/utilities/tether-utils/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "tether-agent"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "tether-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "circular-buffer",

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tether-utils"
 description = "Utilities for Tether Systems"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RandomStudio/tether"

--- a/utilities/tether-utils/Cargo.toml
+++ b/utilities/tether-utils/Cargo.toml
@@ -13,8 +13,8 @@ name = "tether"
 
 
 [dependencies]
-# tether-agent = { path = "../../base_agent/rs" }
-tether-agent = "0.11"
+tether-agent = { path = "../../base_agent/rs" }
+# tether-agent = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 rmp-serde = "1.1.1"

--- a/utilities/tether-utils/examples/api.rs
+++ b/utilities/tether-utils/examples/api.rs
@@ -16,12 +16,7 @@ fn demo_receive() {
         .build()
         .expect("failed to init/connect Tether Agent");
 
-    let options = ReceiveOptions {
-        subscribe_topic: None,
-        subscribe_role: None,
-        subscribe_id: None,
-        subscribe_plug: None,
-    };
+    let options = ReceiveOptions::default();
 
     receive(&options, &tether_agent, |_plug_name, message, decoded| {
         let contents = decoded.unwrap_or("(empty/invalid message)".into());

--- a/utilities/tether-utils/src/tether_receive.rs
+++ b/utilities/tether-utils/src/tether_receive.rs
@@ -38,6 +38,7 @@ pub fn receive(
                 &options.subscribe_id, &options.subscribe_role, &options.subscribe_plug
             );
             PlugOptionsBuilder::create_input("all")
+                .name(options.subscribe_plug.as_deref())
                 .role(options.subscribe_role.as_deref())
                 .id(options.subscribe_id.as_deref())
                 .name(options.subscribe_plug.as_deref())

--- a/utilities/tether-utils/src/tether_receive.rs
+++ b/utilities/tether-utils/src/tether_receive.rs
@@ -41,58 +41,7 @@ pub fn receive(
 ) {
     info!("Tether Receive Utility");
 
-    let input_def = {
-        if options.subscribe_id.is_some()
-            || options.subscribe_role.is_some()
-            || options.subscribe_plug_name.is_some()
-        {
-            debug!(
-                "TPT Overrides apply: {:?}, {:?}, {:?}",
-                &options.subscribe_id, &options.subscribe_role, &options.subscribe_plug_name
-            );
-            PlugOptionsBuilder::create_input(match &options.subscribe_plug_name {
-                Some(provided_name) => {
-                    if provided_name.as_str() == "+" {
-                        "any"
-                    } else {
-                        &provided_name
-                    }
-                }
-                None => "any",
-            })
-            .role(options.subscribe_role.as_deref())
-            .id(options.subscribe_id.as_deref())
-            .name(match &options.subscribe_plug_name {
-                Some(provided_name_part) => {
-                    if provided_name_part.as_str() == "+" {
-                        Some("+")
-                    } else {
-                        None
-                    }
-                }
-                None => {
-                    if options.subscribe_id.is_some() || options.subscribe_role.is_some() {
-                        // No plug name part was supplied, but other parts were; therefore
-                        // in this case Tether Receive should subscribr to all messages
-                        // matching or both of the specified Agent and/or Role
-                        Some("+")
-                    } else {
-                        // No plug name part was supplied, but neither was anything else
-                        // Logically, we shouldn't reach this point because of the outer condition
-                        // but it must be provided here for completeness
-                        None
-                    }
-                }
-            })
-        } else {
-            debug!(
-                "Using custom override topic \"{:?}\"",
-                &options.subscribe_topic
-            );
-            PlugOptionsBuilder::create_input("custom")
-                .topic(Some(options.subscribe_topic.as_deref().unwrap_or("#")))
-        }
-    };
+    let input_def = build_receiver_plug(options);
 
     let input = input_def
         .build(tether_agent)
@@ -131,5 +80,251 @@ pub fn receive(
         if !did_work {
             std::thread::sleep(std::time::Duration::from_micros(100)); //0.1 ms
         }
+    }
+}
+
+fn build_receiver_plug(options: &ReceiveOptions) -> PlugOptionsBuilder {
+    if options.subscribe_id.is_some()
+        || options.subscribe_role.is_some()
+        || options.subscribe_plug_name.is_some()
+    {
+        debug!(
+            "TPT Overrides apply: {:?}, {:?}, {:?}",
+            &options.subscribe_id, &options.subscribe_role, &options.subscribe_plug_name
+        );
+        PlugOptionsBuilder::create_input(match &options.subscribe_plug_name {
+            Some(provided_name) => {
+                if provided_name.as_str() == "+" {
+                    "any"
+                } else {
+                    &provided_name
+                }
+            }
+            None => "any",
+        })
+        .role(options.subscribe_role.as_deref())
+        .id(options.subscribe_id.as_deref())
+        .name(match &options.subscribe_plug_name {
+            Some(provided_name_part) => {
+                if provided_name_part.as_str() == "+" {
+                    Some("+")
+                } else {
+                    None
+                }
+            }
+            None => {
+                if options.subscribe_id.is_some() || options.subscribe_role.is_some() {
+                    // No plug name part was supplied, but other parts were; therefore
+                    // in this case Tether Receive should subscribr to all messages
+                    // matching or both of the specified Agent and/or Role
+                    Some("+")
+                } else {
+                    // No plug name part was supplied, but neither was anything else
+                    // Logically, we shouldn't reach this point because of the outer condition
+                    // but it must be provided here for completeness
+                    None
+                }
+            }
+        })
+    } else {
+        debug!(
+            "Using custom override topic \"{:?}\"",
+            &options.subscribe_topic
+        );
+        PlugOptionsBuilder::create_input("custom")
+            .topic(Some(options.subscribe_topic.as_deref().unwrap_or("#")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tether_agent::TetherAgentOptionsBuilder;
+
+    use crate::tether_receive::build_receiver_plug;
+
+    use super::ReceiveOptions;
+
+    #[test]
+    fn default_options() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions::default();
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "custom");
+        assert_eq!(receive_plug.topic(), "#");
+    }
+
+    #[test]
+    fn only_topic_custom() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: None,
+            subscribe_id: None,
+            subscribe_plug_name: None,
+            subscribe_topic: Some("some/special/plug".into()),
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "custom");
+        assert_eq!(receive_plug.topic(), "some/special/plug");
+    }
+
+    #[test]
+    fn only_plug_name() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: None,
+            subscribe_id: None,
+            subscribe_plug_name: Some("something".into()),
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "something");
+        assert_eq!(receive_plug.topic(), "+/+/something");
+    }
+
+    #[test]
+    fn only_role() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: Some("something".into()),
+            subscribe_id: None,
+            subscribe_plug_name: None,
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "any");
+        assert_eq!(receive_plug.topic(), "something/+/+");
+    }
+
+    #[test]
+    fn only_id() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: None,
+            subscribe_id: Some("something".into()),
+            subscribe_plug_name: None,
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "any");
+        assert_eq!(receive_plug.topic(), "+/something/+");
+    }
+
+    #[test]
+    fn role_and_id() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: Some("x".into()),
+            subscribe_id: Some("y".into()),
+            subscribe_plug_name: None,
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "any");
+        assert_eq!(receive_plug.topic(), "x/y/+");
+    }
+
+    #[test]
+    fn role_and_plug_name() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: Some("x".into()),
+            subscribe_id: None,
+            subscribe_plug_name: Some("z".into()),
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "z");
+        assert_eq!(receive_plug.topic(), "x/+/z");
+    }
+
+    #[test]
+    fn spec_all_three() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: Some("x".into()),
+            subscribe_id: Some("y".into()),
+            subscribe_plug_name: Some("z".into()),
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "z");
+        assert_eq!(receive_plug.topic(), "x/y/z");
+    }
+
+    #[test]
+    fn redundant_but_valid() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+
+        let options = ReceiveOptions {
+            subscribe_role: None,
+            subscribe_id: None,
+            subscribe_plug_name: Some("+".into()),
+            subscribe_topic: None,
+        };
+
+        let receive_plug = build_receiver_plug(&options)
+            .build(&tether_agent)
+            .expect("build failed");
+
+        assert_eq!(receive_plug.name(), "any");
+        assert_eq!(receive_plug.topic(), "+/+/+");
     }
 }


### PR DESCRIPTION
The Tether Receive utility, in particular, was producing some invalid subscription topics in certain cases. This was partly due to a flaw in the settings logic in Tether Receive itself, but it was also due to some confusing and inconsistent options in the Rust Base Agent itself.

This is related to details of the `ThreePartTopic` options.

Specifically, we expect that:

1. When constructing a `PlugDefinition::InputPlug`:
    1. If no custom options are specified at all (i.e. the end-user did **not** call `.role`, `.id` or `.name`, **or** they called these with `None`):
        1. The topic will be constructed as `+/+/plugName` where `plugName` is exactly the same as the "original" plug name given in `PlugOptionsBuilder::create_input("plugName")`
    2. If custom options are given for Role and/or ID (i.e. the end-user **did** call `.role` and/or `.id` with `Some(_)`) **but** the Plug Name part was **not** specified (i.e. the end-user did **not** call `.name` or they called it with `None`): 
        1. The topic will be constructed as `specified/+/plugName` or `+/specified/plugName` or `specified/specified/plugName` where `specified` is what was given in `.role("specified")` and/or `.id("specified")`, while `plugName` is the same as the original
    3. If the end-user specifically wants to specify the Role and/or the ID, but **otherwise wants to match any message matching one or both of these** then they **must** explicitly call `.name(Some("+")` or the more convenient (and functionally equivalent) `.any_plug`. The result being:
        1. In this special case, the internal "plug name" will remain unchanged (keeps the `name` used in `PlugOptionsBuilder::create_input(name: &str)`) but the **topic** will be build such that the Plug Name part is replaced with `+` as expected.
        1. For example, `
        PlugOptionsBuilder::create_input("someplug").role("someRole").id("someID).any_plug()` will produce the topic `someplug/someRole/+`
    4. It is possible to produce a topic such as `+/+/+` by specifying nothing for Role or ID, but calling `.any_plug()` or `.name(Some("+")` even though this is redundant (equivalent to `#`).
2. When using Tether Receive utility (either via library API or command-line executable):
    1. The default options (specifying `None` for all properties) produces an InputPlug with the name `"custom"` but the topic `"#"`.
    2. Specifying any of `subscribe_role`, `subscribe_id`, `subscribe_plug_name` will result in the following:
        1. `None` for Role and ID will always produce `"+"` in their respective position (part) of the topic, as expected
        2. The `subscribe_plug_name` property is handled more carefully:
            1. If **only** the plug name is specified (e.g. `--plug.name myMessages` or `subscribe_plug_name: Some("myMessages)`), but **nothing else**, we assume the user wants to subscribe to, e.g. `"+/+/myMessages"`
            1. If a plug name is given **and** a Role and/or ID, (e.g. `--plug.name myMessages --plug.role someAgentRole`) then we assume the user wants to subscribe to, e.g. `someAgentRole/+/myMessages`
            1. If a plug name is given as `"+"`, then internally we keep the name `"any"` but use the wildcard in the Plug Name position in the generated topic



In the case of the changes to the Tether Base Agent, the unit tests have been adjusted to check the above carefully.

New unit tests have been added to Tether Receive utility.

The Tether Receive utility now behaves as expected:
- `tether receive` => produces topic `"#"`
- `tether receive --plug.name something` => produces topic `"+/+/something"`
- `tether receive --plug.role something` => produces topic `"something/+/+"`
- `tether receive --plug.id something` => produces topic `"+/something/"`
- `tether receive --plug.role x --plug.id y` => produces topic `"x/y/+"`
- `tether receive --plug.role x --plug.name z` => produces topic `"x/+/z"`
- `tether receive --plug.role x --plug.id y --plug.name z` => produces topic `"x/y/z"`

