### PR TITLE
JS Base Agent gets better topic building ergonomics

### DIFF
--- a/base_agent/js/package-lock.json
+++ b/base_agent/js/package-lock.json
@@ -20,7 +20,7 @@
         "@tsconfig/node20": "^20.1.2",
         "@tsconfig/recommended": "^1.0.3",
         "@tsconfig/vite-react": "^2.0.1",
-        "@types/jest": "^28.1.6",
+        "@types/jest": "^28.1.8",
         "@types/node": "^15.0.3",
         "@types/uuid": "^8.3.4",
         "jest": "^28.1.3",
@@ -1075,12 +1075,12 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "dependencies": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
       }
     },
@@ -5265,12 +5265,12 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "requires": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
       }
     },

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-agent",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -23,7 +23,7 @@
     "@tsconfig/node20": "^20.1.2",
     "@tsconfig/recommended": "^1.0.3",
     "@tsconfig/vite-react": "^2.0.1",
-    "@types/jest": "^28.1.6",
+    "@types/jest": "^28.1.8",
     "@types/node": "^15.0.3",
     "@types/uuid": "^8.3.4",
     "jest": "^28.1.3",

--- a/base_agent/js/package.json
+++ b/base_agent/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-agent",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/base_agent/js/src/Plug.ts
+++ b/base_agent/js/src/Plug.ts
@@ -114,7 +114,7 @@ export class OutputPlug extends Plug {
         buildOutputPlugTopic(
           name,
           agent.getConfig().role,
-          agent.getConfig().id
+          options ? options.id : agent.getConfig().id
         ),
     });
     this.publishOptions = options?.publishOptions || {

--- a/base_agent/js/src/index.test.ts
+++ b/base_agent/js/src/index.test.ts
@@ -28,6 +28,20 @@ describe("building topic strings", () => {
     agent.disconnect();
   });
 
+  test("Agent with custom ID, Output Plug with custom still overrides", async () => {
+    const agent = await TetherAgent.create("tester", {
+      id: "originalSpecialGroup",
+    });
+    const output = new OutputPlug(agent, "somePlugName", {
+      id: "overrideOnPlugCreation",
+    });
+    expect(output.getDefinition().name).toEqual("somePlugName");
+    expect(output.getDefinition().topic).toEqual(
+      "tester/overrideOnPlugCreation/somePlugName"
+    );
+    agent.disconnect();
+  });
+
   test("Agent with custom ID, Input Plug with defaults; still generic", async () => {
     const agent = await TetherAgent.create("tester", { id: "specialGroup" });
     const input = await InputPlug.create(agent, "somePlugName");

--- a/base_agent/js/src/index.test.ts
+++ b/base_agent/js/src/index.test.ts
@@ -1,4 +1,72 @@
+import { InputPlug, OutputPlug, TetherAgent } from ".";
 import { topicMatchesPlug } from "./Plug";
+
+describe("building topic strings", () => {
+  test("Default Output Plug, no overrides", async () => {
+    const agent = await TetherAgent.create("tester");
+    const output = new OutputPlug(agent, "somePlugName");
+    expect(output.getDefinition().name).toEqual("somePlugName");
+    expect(output.getDefinition().topic).toEqual("tester/any/somePlugName");
+    agent.disconnect();
+  });
+
+  test("Default Input Plug, no overrides", async () => {
+    const agent = await TetherAgent.create("tester");
+    const input = await InputPlug.create(agent, "somePlugName");
+    expect(input.getDefinition().name).toEqual("somePlugName");
+    expect(input.getDefinition().topic).toEqual("+/+/somePlugName");
+    agent.disconnect();
+  });
+
+  test("Agent with custom ID, Output Plug with defaults", async () => {
+    const agent = await TetherAgent.create("tester", { id: "specialGroup" });
+    const output = new OutputPlug(agent, "somePlugName");
+    expect(output.getDefinition().name).toEqual("somePlugName");
+    expect(output.getDefinition().topic).toEqual(
+      "tester/specialGroup/somePlugName"
+    );
+    agent.disconnect();
+  });
+
+  test("Agent with custom ID, Input Plug with defaults; still generic", async () => {
+    const agent = await TetherAgent.create("tester", { id: "specialGroup" });
+    const input = await InputPlug.create(agent, "somePlugName");
+    expect(input.getDefinition().name).toEqual("somePlugName");
+    expect(input.getDefinition().topic).toEqual("+/+/somePlugName");
+    agent.disconnect();
+  });
+
+  test("Override ID and/or Role when creating Input", async () => {
+    const agent = await TetherAgent.create("tester");
+
+    const inputCustomID = await InputPlug.create(agent, "somePlugName", {
+      id: "stillSpecial",
+    });
+    expect(inputCustomID.getDefinition().name).toEqual("somePlugName");
+    expect(inputCustomID.getDefinition().topic).toEqual(
+      "+/stillSpecial/somePlugName"
+    );
+
+    const inputCustomRole = await InputPlug.create(agent, "somePlugName", {
+      role: "specialRole",
+    });
+    expect(inputCustomRole.getDefinition().name).toEqual("somePlugName");
+    expect(inputCustomRole.getDefinition().topic).toEqual(
+      "specialRole/+/somePlugName"
+    );
+
+    const inputCustomBoth = await InputPlug.create(agent, "somePlugName", {
+      id: "id2",
+      role: "role2",
+    });
+    expect(inputCustomBoth.getDefinition().name).toEqual("somePlugName");
+    expect(inputCustomBoth.getDefinition().topic).toEqual(
+      "role2/id2/somePlugName"
+    );
+
+    agent.disconnect();
+  });
+});
 
 describe("matching topics to plugs", () => {
   test("if Plug specified full topic, i.e. no wildcards, then only exact matches", () => {

--- a/base_agent/js/tsconfig.json
+++ b/base_agent/js/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "declaration": true
   },
+  "typeAcquisition": { "include": ["jest"] },
   "include": [
     "src/**/*"
   ],

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -311,6 +311,24 @@ mod tests {
     }
 
     #[test]
+    /// This is a fairly trivial example, but contrast with the test
+    /// `output_plug_default_but_agent_id_custom`: although a custom ID was set for the
+    /// Agent, this does not affect the Topic for an Input Plug created without any
+    /// explicit overrides.
+    fn default_input_plug_with_agent_custom_id() {
+        // verbose_logging();
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .id(Some("verySpecialGroup"))
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+        let input = PlugOptionsBuilder::create_input("one")
+            .build(&tether_agent)
+            .unwrap();
+        assert_eq!(input.name(), "one");
+        assert_eq!(input.topic(), "+/+/one");
+    }
+
+    #[test]
     fn default_output_plug() {
         let tether_agent = TetherAgentOptionsBuilder::new("tester")
             .build()

--- a/base_agent/rs/src/plugs/options.rs
+++ b/base_agent/rs/src/plugs/options.rs
@@ -323,6 +323,25 @@ mod tests {
     }
 
     #[test]
+    /// This is identical to the case in which an Output Plug is created with defaults (no overrides),
+    /// BUT the Agent had a custom ID set, which means that the final topic includes this custom
+    /// ID/Group value.
+    fn output_plug_default_but_agent_id_custom() {
+        let tether_agent = TetherAgentOptionsBuilder::new("tester")
+            .id(Some("specialCustomGrouping"))
+            .build()
+            .expect("sorry, these tests require working localhost Broker");
+        let input = PlugOptionsBuilder::create_output("somethingStandard")
+            .build(&tether_agent)
+            .unwrap();
+        assert_eq!(input.name(), "somethingStandard");
+        assert_eq!(
+            input.topic(),
+            "tester/specialCustomGrouping/somethingStandard"
+        );
+    }
+
+    #[test]
     fn input_id_andor_role() {
         let tether_agent = TetherAgentOptionsBuilder::new("tester")
             .build()

--- a/examples/react-ts/package-lock.json
+++ b/examples/react-ts/package-lock.json
@@ -37,6 +37,10 @@
         "loglevel": "^1.8.0"
       },
       "devDependencies": {
+        "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/recommended": "^1.0.3",
+        "@tsconfig/vite-react": "^2.0.1",
         "@types/jest": "^28.1.6",
         "@types/node": "^15.0.3",
         "@types/uuid": "^8.3.4",
@@ -44,7 +48,7 @@
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^4.5.5"
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4811,6 +4815,10 @@
       "version": "file:../../base_agent/js",
       "requires": {
         "@msgpack/msgpack": "^3.0.0-beta2",
+        "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/recommended": "^1.0.3",
+        "@tsconfig/vite-react": "^2.0.1",
         "@types/jest": "^28.1.6",
         "@types/node": "^15.0.3",
         "@types/uuid": "^8.3.4",
@@ -4822,7 +4830,7 @@
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^4.5.5"
+        "typescript": "^5.2.2"
       }
     },
     "text-table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "tether",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
The Rust Base Agent has provided convenient ways to build the topic for Plugs automatically, without necessarily requiring the end-user developer to manually build strings; the JS Base Agent has not had this functionality.

For convenience, you can now specify customised "parts" of the three-part-topic in various ways:

1. Optionally set an ID when creating the Tether Agent instance (instead of the default `any`).
2. Set an ID or Role when creating an Input Plug or Output Plug. The effect of this is slightly different for Input / Output Plugs:
    1. **For Output Plugs:**  The Role part will always be overridden if specified at the point of Output Plug creation, _otherwise it will fall back to the Role which was required to be set on the creation of the Tether Agent_. The ID part will always be overridden if specified at the point of Output Plug creation, _otherwise it will fall back to the default `any`._
    2. **For Input Plugs:** The Role and ID parts will be overridden if specified at the point of Input Plug creation, _otherwise they will both default back to `+`_, i.e. wildcard match for "any role" and/or "any id".
3. Finally, you can use `overrideTopic` to build the full topic manually; this will override anything that may have been set using any of the other methods above.